### PR TITLE
Expand Envs #22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "hoard"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "directories",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_test",
+ "serial_test",
  "structopt",
  "tempfile",
  "thiserror",
@@ -269,6 +270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +289,15 @@ name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -323,6 +342,31 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.5",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "petgraph"
@@ -499,6 +543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +576,34 @@ checksum = "b4bb5fef7eaf5a97917567183607ac4224c5b451c15023930f23b937cce879fe"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "rand",
+ "regex",
  "serde",
  "serde_test",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoard"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Michael Bryant <shadow53@shadow53.com>"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,6 @@ which = "4.1"
 [dev-dependencies]
 maplit = "1.0"
 rand = "0.8"
+serial_test = "0.5"
 serde_test = "1.0"
 tempfile = "3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ env_logger = "0.8"
 directories = "3.0.1"
 hostname = "0.3"
 log = "0.4.14"
+once_cell = "1.7"
 petgraph = "0.5"
+regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3.21"
 thiserror = "1.0.24"
@@ -27,7 +29,6 @@ which = "4.1"
 
 [dev-dependencies]
 maplit = "1.0"
-once_cell = "1.7"
 rand = "0.8"
 serde_test = "1.0"
 tempfile = "3.2"

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -1,0 +1,136 @@
+//! Expand environment variables inside of a path.
+//!
+//! The only function exported from this module is [`expand_env_in_path`].
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::env;
+use std::path::PathBuf;
+
+// Following the example of `std::env::set_var`, the only things disallowed are
+// the equals sign and the NUL character.
+//
+// The `+?` is non-greedy matching, which is necessary for if there are multiple variables.
+static ENV_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"\$\{[^(=|\x{0})]+?}"#).expect("failed to compile regular expression")
+});
+
+/// Takes the input string, expands all environment variables, and returns the
+/// expanded string as a [`PathBuf`].
+///
+/// # Example
+///
+/// ```
+/// use hoard::env_vars::expand_env_in_path;
+/// use std::path::PathBuf;
+///
+/// let template = "/some/${CUSTOM_VAR}/path";
+/// std::env::set_var("CUSTOM_VAR", "foobar");
+/// let path = expand_env_in_path(template)
+///     .expect("failed to expand path");
+/// assert_eq!(path, PathBuf::from("/some/foobar/path"));
+/// ```
+///
+/// # Errors
+///
+/// - Any [`VarError`](env::VarError) from looking up the environment variable's value.
+pub fn expand_env_in_path(path: &str) -> Result<PathBuf, env::VarError> {
+    let mut new_path = path.to_owned();
+    let mut start: usize = 0;
+    let mut old_start: usize;
+
+    while let Some(mat) = ENV_REGEX.find(&new_path[start..]) {
+        let var = mat.as_str();
+        let var = &var[2..var.len() - 1];
+        let value = env::var(var)?;
+
+        old_start = start;
+        start = start + mat.start() + value.len() + 1;
+        if start > (new_path.len() + value.len() - mat.as_str().len()) {
+            start = new_path.len();
+        }
+
+        let range = mat.range();
+        new_path.replace_range(range.start + old_start..range.end + old_start, &value);
+    }
+
+    // Splitting into components and collecting will collapse multiple separators.
+    Ok(PathBuf::from(new_path).components().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::MAIN_SEPARATOR;
+
+    fn get_home_without_starting_sep() -> String {
+        let home = env::var("HOME").expect("failed to find HOME");
+        home.strip_prefix(MAIN_SEPARATOR)
+            .map_or(home.clone(), std::borrow::ToOwned::to_owned)
+    }
+
+    #[test]
+    fn path_starting_with_var() {
+        let home = get_home_without_starting_sep();
+        let expected: PathBuf = ["/", &home, "testdir", "testfile"].iter().collect();
+        let result =
+            expand_env_in_path("${HOME}/testdir/testfile").expect("failed to expand env in path");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn path_wrapping_var() {
+        let home = get_home_without_starting_sep();
+        let expected: PathBuf = vec!["/start", &home, "testdir"].into_iter().collect();
+        let result =
+            expand_env_in_path("/start/${HOME}/testdir").expect("failed to expand env in path");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn path_ending_in_var() {
+        let home = get_home_without_starting_sep();
+        let expected: PathBuf = vec!["/start", "testdir", &home].into_iter().collect();
+        let result =
+            expand_env_in_path("/start/testdir/${HOME}").expect("failed to expand env in path");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn path_without_var_stays_same() {
+        let template = "/path/without/variables";
+        let expected = PathBuf::from(template);
+        let result =
+            expand_env_in_path(template).expect("failed to process path without variables");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn path_with_two_variables() {
+        let home = get_home_without_starting_sep();
+        let expected: PathBuf = vec!["/start", &home, "testdir", &home, "end"]
+            .into_iter()
+            .collect();
+        let result = expand_env_in_path("/start/${HOME}/testdir/${HOME}/end")
+            .expect("failed to expand env in path");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn path_with_variables_without_braces_not_expanded() {
+        let template = "/path/with/$INVALID/variable";
+        let expected = PathBuf::from(template);
+        let result =
+            expand_env_in_path(template).expect("failed to process path with invalid variable");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn path_with_win32_style_variable_not_expanded() {
+        let template = "/path/with/%INVALID%/variable";
+        let expected = PathBuf::from(template);
+        let result =
+            expand_env_in_path(template).expect("failed to process path with invalid variable");
+        assert_eq!(result, expected);
+    }
+}

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 //
 // The `+?` is non-greedy matching, which is necessary for if there are multiple variables.
 static ENV_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"\$\{[^(=|\x{0})]+?}"#).expect("failed to compile regular expression")
+    Regex::new(r#"\$\{[^(=|\x{0}|$)]+?}"#).expect("failed to compile regular expression")
 });
 
 /// Takes the input string, expands all environment variables, and returns the
@@ -199,5 +199,13 @@ mod tests {
         env: "TEST_HOME",
         value: "${HOME}",
         expected: PathBuf::from("${HOME}")
+    }
+
+    test_env! {
+        name: var_inside_var,
+        input: "${WRAPPING${TEST_VAR}VARIABLE}",
+        env: "TEST_VAR",
+        value: "_",
+        expected: PathBuf::from("${WRAPPING_VARIABLE}")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use config::Config;
 pub mod combinator;
 pub mod command;
 pub mod config;
+pub mod env_vars;
 
 /// The default file name of the configuration file.
 pub const CONFIG_FILE_NAME: &str = "config.toml";


### PR DESCRIPTION
Resolves #22.

This adds a module for parsing a path containing environment variables. The variable names *must* be written as `${VARIABLE_NAME}`, which I think makes parsing easier than the opposite. Variables are *not* recursively expanded.