### PR TITLE
#26: Prevent file footguns

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
       pytests: ${{ steps.filter.outputs.pytests }}}
     steps:
       - uses: actions/checkout@v2
-      - uses: dorny/paths-filter
+      - uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -184,7 +184,7 @@ jobs:
           command: build
 
       - name: Install Python
-        uses: actions/setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: "3.9"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,6 +158,13 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
+        if: ${{ matrix.os != "macos-latest" }}
         env:
-            HOME: /tmp/github
+            HOME: '/home/runner'
             HOMEPATH: 'C:\Users\github'
+
+      - name: Test Last Paths
+        run: python ci-tests/test.py last_paths
+        if: ${{ matrix.os == "macos-latest" }}
+        env:
+            HOME: '/Users/runner'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,5 +158,3 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
-        env:
-          HOARD_LOG: "trace"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,3 +158,6 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
+        env:
+            HOME: /tmp/github
+            HOMEPATH: 'C:\Users\github'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,3 +190,6 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
+
+      - name: Test Remote Operations
+        run: python ci-tests/test.py operation

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,3 +116,46 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage.outputs.report }}
+
+  integration-tests:
+    name: "Integration Tests"
+    needs: check-stable
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-stable-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-stable-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-stable-bin-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cargo Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Test Last Paths
+        run: ./ci-tests/test.py last_paths
+        shell: python

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -157,5 +157,4 @@ jobs:
           command: build
 
       - name: Test Last Paths
-        run: ./ci-tests/test.py last_paths
-        shell: python
+        run: python ci-tests/test.py last_paths

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,3 +158,5 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
+        env:
+          HOARD_LOG: "trace"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,9 +3,31 @@ on: [push]
 name: Commit Checks
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      cargo: ${{ steps.filter.outputs.cargo }}
+      pytests: ${{ steps.filter.outputs.pytests }}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter
+        id: filter
+        with:
+          filters: |
+            cargo:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            rust:
+              - '**/*.rs'
+            pytests:
+              - 'ci-tests/**'
+
   fmt:
     name: Cargo fmt
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -26,6 +48,8 @@ jobs:
   check-stable:
     name: Check Commit
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.cargo == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -68,6 +92,8 @@ jobs:
   check-nightly:
     name: Check Commit
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.cargo == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -119,7 +145,8 @@ jobs:
 
   integration-tests:
     name: "Integration Tests"
-    needs: check-stable
+    needs: [check-stable, changes]
+    if: ${{ needs.check-stable.result != 'failure' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.cargo == 'true' || needs.changes.outputs.pytests == 'true') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,13 +158,13 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
-        if: ${{ matrix.os != "macos-latest" }}
+        if: ${{ matrix.os != 'macos-latest' }}
         env:
             HOME: '/home/runner'
             HOMEPATH: 'C:\Users\github'
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
-        if: ${{ matrix.os == "macos-latest" }}
+        if: ${{ matrix.os == 'macos-latest' }}
         env:
             HOME: '/Users/runner'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,13 +158,15 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
+        shell: bash
         if: ${{ matrix.os != 'macos-latest' }}
         env:
-            HOME: '/home/runner'
-            HOMEPATH: 'C:\Users\github'
+          HOME: '/home/runner'
+          HOMEPATH: 'C:\Users\github'
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
+        shell: bash
         if: ${{ matrix.os == 'macos-latest' }}
         env:
-            HOME: '/Users/runner'
+          HOME: '/Users/runner'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -188,6 +188,10 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Install tree (macos)
+        if: matrix.os == 'macos-latest'
+        run: brew install tree
+
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,15 +158,3 @@ jobs:
 
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths
-        shell: bash
-        if: ${{ matrix.os != 'macos-latest' }}
-        env:
-          HOME: '/home/runner'
-          HOMEPATH: 'C:\Users\github'
-
-      - name: Test Last Paths
-        run: python ci-tests/test.py last_paths
-        shell: bash
-        if: ${{ matrix.os == 'macos-latest' }}
-        env:
-          HOME: '/Users/runner'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -183,5 +183,10 @@ jobs:
         with:
           command: build
 
+      - name: Install Python
+        uses: actions/setup-python
+        with:
+          python-version: "3.9"
+
       - name: Test Last Paths
         run: python ci-tests/test.py last_paths

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,18 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,33 +47,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
@@ -123,37 +88,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
-dependencies = [
- "autocfg",
- "cfg-if",
- "lazy_static",
- "loom",
-]
-
-[[package]]
 name = "directories"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
@@ -173,60 +120,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
-name = "generator"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -270,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -280,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]
@@ -301,9 +224,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "lock_api"
@@ -321,17 +244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -382,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "parking_lot"
@@ -406,7 +318,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
@@ -423,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "ppv-lite86"
@@ -459,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -477,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -489,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -499,46 +411,39 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -577,34 +482,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -614,18 +495,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -645,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bb5fef7eaf5a97917567183607ac4224c5b451c15023930f23b937cce879fe"
+checksum = "de9e52f2f83e2608a121618b6d3885b514613aac702306232c4f035ff60fdb56"
 dependencies = [
  "serde",
 ]
@@ -676,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
@@ -697,9 +578,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static",
@@ -708,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -721,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -739,7 +620,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -755,18 +636,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -826,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -856,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -878,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -890,9 +771,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uuid"
@@ -900,7 +781,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
  "serde",
 ]
 
@@ -912,15 +793,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
@@ -930,11 +805,12 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"
-version = "4.1.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
  "either",
+ "lazy_static",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "directories"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +136,16 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -162,6 +190,7 @@ dependencies = [
  "directories",
  "hostname",
  "maplit",
+ "md-5",
  "once_cell",
  "petgraph",
  "rand",
@@ -268,6 +297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +337,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parking_lot"
@@ -756,6 +802,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,8 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
+ "time",
  "winapi",
 ]
 
@@ -233,6 +235,7 @@ dependencies = [
 name = "hoard"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "directories",
  "hostname",
  "maplit",
@@ -241,6 +244,7 @@ dependencies = [
  "rand",
  "regex",
  "serde",
+ "serde_json",
  "serde_test",
  "serial_test",
  "structopt",
@@ -776,6 +780,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "which",
 ]
 
@@ -878,6 +879,16 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.2",
+ "serde",
+]
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ repository = "https://github.com/Shadow53/hoard"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing-subscriber = { version = "0.2", features = ["ansi"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "3.0.1"
 hostname = "0.3"
-tracing = "0.1"
+md-5 = "0.9"
 once_cell = "1.7"
 petgraph = "0.5"
 regex = "1.5"
@@ -24,6 +23,8 @@ serde_json = "1.0"
 structopt = "0.3.21"
 thiserror = "1.0.24"
 toml = "0.5.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.2", features = ["ansi"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 which = "4.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3.21"
 thiserror = "1.0.24"
 toml = "0.5.8"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 which = "4.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/Shadow53/hoard"
 
 [dependencies]
 tracing-subscriber = { version = "0.2", features = ["ansi"] }
+chrono = { version = "0.4", features = ["serde"] }
 directories = "3.0.1"
 hostname = "0.3"
 tracing = "0.1"
@@ -19,6 +20,7 @@ once_cell = "1.7"
 petgraph = "0.5"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 structopt = "0.3.21"
 thiserror = "1.0.24"
 toml = "0.5.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:alpine AS build
 
-RUN apk add build-base tree
+RUN apk add build-base
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY src src
@@ -8,9 +8,10 @@ RUN cargo build
 
 FROM python:alpine
 
-ENV CI=true GITHUB_ACTIONS=true
+ENV CI=true GITHUB_ACTIONS=true HOARD_LOG=trace
 COPY ci-tests ci-tests
 COPY --from=build target/debug/hoard target/debug/hoard
 
+RUN apk add tree
 RUN python3 ci-tests/test.py last_paths
 RUN python3 ci-tests/test.py operation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:alpine AS build
+
+RUN apk add build-base
+COPY . .
+RUN cargo build
+
+FROM python:alpine
+
+ENV CI=true GITHUB_ACTIONS=true
+COPY ci-tests ci-tests
+COPY --from=build target/debug/hoard target/debug/hoard
+
+RUN python3 ci-tests/test.py last_paths

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM rust:alpine AS build
 
-RUN apk add build-base
-COPY . .
+RUN apk add build-base tree
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY src src
 RUN cargo build
 
 FROM python:alpine
@@ -11,3 +13,4 @@ COPY ci-tests ci-tests
 COPY --from=build target/debug/hoard target/debug/hoard
 
 RUN python3 ci-tests/test.py last_paths
+RUN python3 ci-tests/test.py operation

--- a/ci-tests/config.toml
+++ b/ci-tests/config.toml
@@ -5,9 +5,9 @@ exclusivity = [
 
 [envs]
 [envs.first]
-    env = [{ var = "USE_ENV", value = "1" }]
+    env = [{ var = "USE_ENV", expected = "1" }]
 [envs.second]
-    env = [{ var = "USE_ENV", value = "2"}]
+    env = [{ var = "USE_ENV", expected = "2" }]
 [envs.windows]
     os = ["windows"]
     env = [{ var = "HOMEPATH" }]

--- a/ci-tests/config.toml
+++ b/ci-tests/config.toml
@@ -1,6 +1,6 @@
 exclusivity = [
     ["first", "second"],
-    ["windows", "linux", "macos"]
+    ["unix", "windows"]
 ]
 
 [envs]
@@ -10,12 +10,10 @@ exclusivity = [
     env = [{ var = "USE_ENV", value = "2"}]
 [envs.windows]
     os = ["windows"]
-[envs.linux]
-    os = ["linux"]
-[envs.macos]
-    os = ["macos"]
+    env = [{ var = "HOMEPATH" }]
 [envs.unix]
     os = ["linux", "macos"]
+    env = [{ var = "HOME" }]
 
 [hoards]
 [hoards.anon_dir]

--- a/ci-tests/config.toml
+++ b/ci-tests/config.toml
@@ -1,0 +1,41 @@
+exclusivity = [
+    ["first", "second"],
+    ["windows", "linux", "macos"]
+]
+
+[envs]
+[envs.first]
+    env = [{ var = "USE_ENV", value = "1" }]
+[envs.second]
+    env = [{ var = "USE_ENV", value = "2"}]
+[envs.windows]
+    os = ["windows"]
+[envs.linux]
+    os = ["linux"]
+[envs.macos]
+    os = ["macos"]
+[envs.unix]
+    os = ["linux", "macos"]
+
+[hoards]
+[hoards.anon_dir]
+    "unix|first"  = "${HOME}/first_anon_dir"
+    "unix|second" = "${HOME}/second_anon_dir"
+    "windows|first"  = "${HOMEPATH}/first_anon_dir"
+    "windows|second" = "${HOMEPATH}/second_anon_dir"
+[hoards.anon_file]
+    "unix|first"  = "${HOME}/first_anon_file"
+    "unix|second" = "${HOME}/second_anon_file"
+    "windows|first"  = "${HOMEPATH}/first_anon_file"
+    "windows|second" = "${HOMEPATH}/second_anon_file"
+[hoards.named]
+    [hoards.named.file]
+        "unix|first"  = "${HOME}/first_named_file"
+        "unix|second" = "${HOME}/second_named_file"
+        "windows|first"  = "${HOMEPATH}/first_named_file"
+        "windows|second" = "${HOMEPATH}/second_named_file"
+    [hoards.named.dir]
+        "unix|first"  = "${HOME}/first_named_dir"
+        "unix|second" = "${HOME}/second_named_dir"
+        "windows|first"  = "${HOMEPATH}/first_named_dir"
+        "windows|second" = "${HOMEPATH}/second_named_dir"

--- a/ci-tests/config.toml
+++ b/ci-tests/config.toml
@@ -19,21 +19,21 @@ exclusivity = [
 [hoards.anon_dir]
     "unix|first"  = "${HOME}/first_anon_dir"
     "unix|second" = "${HOME}/second_anon_dir"
-    "windows|first"  = "${HOMEPATH}/first_anon_dir"
-    "windows|second" = "${HOMEPATH}/second_anon_dir"
+    "windows|first"  = "C:/${HOMEPATH}/first_anon_dir"
+    "windows|second" = "C:/${HOMEPATH}/second_anon_dir"
 [hoards.anon_file]
     "unix|first"  = "${HOME}/first_anon_file"
     "unix|second" = "${HOME}/second_anon_file"
-    "windows|first"  = "${HOMEPATH}/first_anon_file"
-    "windows|second" = "${HOMEPATH}/second_anon_file"
+    "windows|first"  = "C:/${HOMEPATH}/first_anon_file"
+    "windows|second" = "C:/${HOMEPATH}/second_anon_file"
 [hoards.named]
     [hoards.named.file]
         "unix|first"  = "${HOME}/first_named_file"
         "unix|second" = "${HOME}/second_named_file"
-        "windows|first"  = "${HOMEPATH}/first_named_file"
-        "windows|second" = "${HOMEPATH}/second_named_file"
+        "windows|first"  = "C:/${HOMEPATH}/first_named_file"
+        "windows|second" = "C:/${HOMEPATH}/second_named_file"
     [hoards.named.dir]
         "unix|first"  = "${HOME}/first_named_dir"
         "unix|second" = "${HOME}/second_named_dir"
-        "windows|first"  = "${HOMEPATH}/first_named_dir"
-        "windows|second" = "${HOMEPATH}/second_named_dir"
+        "windows|first"  = "C:/${HOMEPATH}/first_named_dir"
+        "windows|second" = "C:/${HOMEPATH}/second_named_dir"

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -101,7 +101,9 @@ def assert_second_tree():
 def run_hoard(command, targets=[], env=None):
     # Run the specified hoard command
     # Should automatically operate on all hoards when targets is empty
-    subprocess.run(["target/debug/hoard", command, *targets], check=True, env=env)
+    for key, val in env.items():
+        os.environ[key] = val
+    subprocess.run(["target/debug/hoard", command, *targets], check=True)
 
 
 def test_last_paths():

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -59,7 +59,7 @@ def setup():
 
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
-            for num in ["1", "2", "3"]:
+            for num in [1, 2, 3]:
                 os.makedirs(f"{home}/{env}_{item}", exist_ok=True)
                 with open(f"{home}/{env}_{item}/{num}", "wb") as file:
                     content = secrets.token_bytes(num * 1024)

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -185,12 +185,13 @@ def test_operation_checker():
     with open(uuid_path, "r") as file:
         uuid = file.readline()
     os.remove(uuid_path)
+
     # Go again, this time with a different uuid
     # This should still succeed because the files have the same checksum
-
     print("========= HOARD RUN #2 =========")
     print("  After removing the UUID file  ")
     run_hoard("backup", env=env)
+
     # Modify a file and backup again so checksums are different the next time
     # This should succeed because this UUID had the last backup
     with open(Path.home().joinpath("first_anon_file"), "rb") as file:
@@ -198,7 +199,6 @@ def test_operation_checker():
     with open(Path.home().joinpath("first_anon_file"), "wb") as file:
         content = secrets.token_bytes(1024)
         file.write(content)
-
     print("========= HOARD RUN #3 =========")
     print(" After replacing a file content ")
     run_hoard("backup", env=env)
@@ -206,10 +206,8 @@ def test_operation_checker():
     # Swap UUIDs and change the file again and try to back up
     # Should fail because a different machine has the most recent backup
     with open(uuid_path, "w") as file:
-        file.truncate(0)
         file.write(uuid)
     with open(Path.home().joinpath("first_anon_file"), "wb") as file:
-        file.truncate(0)
         file.write(old_content)
     try:
         print("========= HOARD RUN #4 =========")

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -20,9 +20,13 @@ def config_file_path():
     if system == 'Linux':
         return Path(f"{home}/.config/hoard/config.toml")
     elif system == 'Darwin':
-        return Path(f"{home}/Library/Application Support/com.shadow53.hoard/config.toml")
+        return Path(
+           f"{home}/Library/Application Support/com.shadow53.hoard/config.toml"
+        )
     elif system == 'Windows':
-        return Path(f"{home}/AppData/Roaming/shadow53/hoard/config/config.toml")
+        return Path(
+            f"{home}/AppData/Roaming/shadow53/hoard/config/config.toml"
+        )
     else:
         raise OSError("could not determine system for CI tests")
 
@@ -73,29 +77,63 @@ def assert_same_tree(path1, path2, direntries=None):
         if not filecmp.cmp(path1, path2, shallow=False):
             raise RuntimeError(f"content of files {path1} and {path2} differ")
     else:
-        matches, mismatches, errors = filecmp.cmpfiles(path1, path2, direntries, shallow=False)
+        matches, mismatches, errors = filecmp.cmpfiles(
+            path1, path2, direntries, shallow=False
+        )
         if errors:
-            raise RuntimeError(f"could not check {errors} inside {path1} and/or {path2}")
+            raise RuntimeError(
+                f"could not check {errors} inside {path1} and/or {path2}"
+            )
         if mismatches:
-            raise RuntimeError(f"contents of files {mismatches} in {path1} and {path2} differ")
+            raise RuntimeError(
+                f"contents of files {mismatches} in {path1} and {path2} differ"
+            )
 
 
 def assert_first_tree():
     home = Path.home()
     data_dir = data_dir_path()
-    assert_same_tree(f"{home}/first_anon_dir", f"{data_dir}/hoards/anon_dir")
-    assert_same_tree(f"{home}/first_anon_file", f"{data_dir}/hoards/anon_file")
-    assert_same_tree(f"{home}/first_named_dir", f"{data_dir}/hoards/named/dir")
-    assert_same_tree(f"{home}/first_named_file", f"{data_dir}/hoards/named/file")
+    assert_same_tree(
+        f"{home}/first_anon_dir",
+        f"{data_dir}/hoards/anon_dir",
+        direntries=[1, 2, 3]
+    )
+    assert_same_tree(
+        f"{home}/first_anon_file",
+        f"{data_dir}/hoards/anon_file"
+    )
+    assert_same_tree(
+        f"{home}/first_named_dir",
+        f"{data_dir}/hoards/named/dir",
+        direntries=[1, 2, 3]
+    )
+    assert_same_tree(
+        f"{home}/first_named_file",
+        f"{data_dir}/hoards/named/file"
+    )
 
 
 def assert_second_tree():
     home = Path.home()
     data_dir = data_dir_path()
-    assert_same_tree(f"{home}/second_anon_dir", f"{data_dir}/hoards/anon_dir")
-    assert_same_tree(f"{home}/second_anon_file", f"{data_dir}/hoards/anon_file")
-    assert_same_tree(f"{home}/second_named_dir", f"{data_dir}/hoards/named/dir")
-    assert_same_tree(f"{home}/second_named_file", f"{data_dir}/hoards/named/file")
+    assert_same_tree(
+        f"{home}/second_anon_dir",
+        f"{data_dir}/hoards/anon_dir",
+        direntries=[1, 2, 3]
+    )
+    assert_same_tree(
+        f"{home}/second_anon_file",
+        f"{data_dir}/hoards/anon_file"
+    )
+    assert_same_tree(
+        f"{home}/second_named_dir",
+        f"{data_dir}/hoards/named/dir",
+        direntries=[1, 2, 3]
+    )
+    assert_same_tree(
+        f"{home}/second_named_file",
+        f"{data_dir}/hoards/named/file"
+    )
 
 
 def run_hoard(command, force=False, targets=[], env=None):
@@ -118,7 +156,9 @@ def test_last_paths():
     # Run hoard with env "second" - this should fail
     try:
         run_hoard("backup", env={"USE_ENV": "2"})
-        raise RuntimeError("Changing environment should have caused last_paths to fail")
+        raise RuntimeError(
+            "Changing environment should have caused last_paths to fail"
+        )
     except subprocess.CalledProcessError:
         pass
     # Doing it again with "first" should still succeed

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -180,4 +180,11 @@ if __name__ == "__main__":
     if len(sys.argv) == 1:
         raise RuntimeError("One argument - the test - is required")
     if sys.argv[1] == "last_paths":
-        test_last_paths()
+        try:
+            test_last_paths()
+        except Exception:
+            print("\nHoards:")
+            subprocess.run(["tree", data_dir_path()])
+            print("\nHome:")
+            subprocess.run(["tree", Path.home()])
+            raise

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -18,15 +18,11 @@ def config_file_path():
     system = platform.system()
     home = Path.home()
     if system == 'Linux':
-        return Path(f"{home}/.config/hoard/config.toml")
+        return home.join(".config", "hoard", "config.toml")
     elif system == 'Darwin':
-        return Path(
-           f"{home}/Library/Application Support/com.shadow53.hoard/config.toml"
-        )
+        return home.join("Library", "Application Support", "com.shadow53.hoard", "config.toml")
     elif system == 'Windows':
-        return Path(
-            f"{home}/AppData/Roaming/shadow53/hoard/config/config.toml"
-        )
+        return home.join("AppData", "Roaming", "shadow53", "hoard", "config", "config.toml")
     else:
         raise OSError("could not determine system for CI tests")
 
@@ -35,11 +31,11 @@ def data_dir_path():
     system = platform.system()
     home = Path.home()
     if system == 'Linux':
-        return Path(f"{home}/.local/share/hoard")
+        return home.join(".local", "share", "hoard")
     elif system == 'Darwin':
-        return Path(f"{home}/Library/Application Support/com.shadow53.hoard")
+        return home.join("Library", "Application Support", "com.shadow53.hoard")
     elif system == 'Windows':
-        return Path(f"{home}/AppData/Roaming/shadow53/hoard/data")
+        return home.join("AppData", "Roaming", "shadow53", "hoard", "data")
     else:
         raise OSError("could not determine system for CI tests")
 
@@ -60,16 +56,16 @@ def setup():
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
             for num in [1, 2, 3]:
-                os.makedirs(f"{home}/{env}_{item}", exist_ok=True)
-                with open(f"{home}/{env}_{item}/{num}", "wb") as file:
+                os.makedirs(home.join(f"{env}_{item}"), exist_ok=True)
+                with open(home.join("{env}_{item}", "{num}"), "wb") as file:
                     content = secrets.token_bytes(num * 1024)
                     file.write(content)
         for item in ["anon_file", "named_file"]:
-            with open(f"{home}/{env}_{item}", "wb") as file:
+            with open(home.join(f"{env}_{item}"), "wb") as file:
                 content = secrets.token_bytes(2048)
                 file.write(content)
     os.makedirs(config_file_path().parent)
-    shutil.copy2("ci-tests/config.toml", config_file_path())
+    shutil.copy2(Path.cwd().join("ci-tests", "config.toml"), config_file_path())
 
 
 def assert_same_tree(path1, path2, *, direntries=None):
@@ -94,22 +90,22 @@ def assert_first_tree():
     home = Path.home()
     data_dir = data_dir_path()
     assert_same_tree(
-        f"{home}/first_anon_dir",
-        f"{data_dir}/hoards/anon_dir",
+        home.join("first_anon_dir"),
+        data_dir.join("hoards", "anon_dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        f"{home}/first_anon_file",
-        f"{data_dir}/hoards/anon_file"
+        home.join("first_anon_file"),
+        data_dir.join("hoards", "anon_file")
     )
     assert_same_tree(
-        f"{home}/first_named_dir",
-        f"{data_dir}/hoards/named/dir",
+        home.join("first_named_dir"),
+        data_dir.join("hoards", "named", "dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        f"{home}/first_named_file",
-        f"{data_dir}/hoards/named/file"
+        home.join("first_named_file"),
+        data_dir.join("hoards", "named", "file")
     )
 
 
@@ -117,22 +113,22 @@ def assert_second_tree():
     home = Path.home()
     data_dir = data_dir_path()
     assert_same_tree(
-        f"{home}/second_anon_dir",
-        f"{data_dir}/hoards/anon_dir",
+        home.join("second_anon_dir"),
+        data_dir.join("hoards", "anon_dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        f"{home}/second_anon_file",
-        f"{data_dir}/hoards/anon_file"
+        home.join("second_anon_file"),
+        data_dir.join("hoards", "anon_file")
     )
     assert_same_tree(
-        f"{home}/second_named_dir",
-        f"{data_dir}/hoards/named/dir",
+        home.join("second_named_dir"),
+        data_dir.join("hoards", "named", "dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        f"{home}/second_named_file",
-        f"{data_dir}/hoards/named/file"
+        home.join("second_named_file"),
+        data_dir.join("hoards", "named", "file")
     )
 
 

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -103,7 +103,7 @@ def run_hoard(command, targets=[], env=None):
     # Should automatically operate on all hoards when targets is empty
     for key, val in env.items():
         os.environ[key] = val
-    subprocess.run(["target/debug/hoard", command, *targets], check=True, env=os.environ)
+    subprocess.run(["target/debug/hoard", command, *targets], check=True)
 
 
 def test_last_paths():

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -145,6 +145,7 @@ def run_hoard(command, *, force=False, targets=[], env=None):
     args = ["target/debug/hoard"]
     if force:
         args.append("--force")
+    args.append(command)
     args += targets
 
     subprocess.run(args, check=True)

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -18,11 +18,11 @@ def config_file_path():
     system = platform.system()
     home = Path.home()
     if system == 'Linux':
-        return home.join(".config", "hoard", "config.toml")
+        return home.joinpath(".config", "hoard", "config.toml")
     elif system == 'Darwin':
-        return home.join("Library", "Application Support", "com.shadow53.hoard", "config.toml")
+        return home.joinpath("Library", "Application Support", "com.shadow53.hoard", "config.toml")
     elif system == 'Windows':
-        return home.join("AppData", "Roaming", "shadow53", "hoard", "config", "config.toml")
+        return home.joinpath("AppData", "Roaming", "shadow53", "hoard", "config", "config.toml")
     else:
         raise OSError("could not determine system for CI tests")
 
@@ -31,11 +31,11 @@ def data_dir_path():
     system = platform.system()
     home = Path.home()
     if system == 'Linux':
-        return home.join(".local", "share", "hoard")
+        return home.joinpath(".local", "share", "hoard")
     elif system == 'Darwin':
-        return home.join("Library", "Application Support", "com.shadow53.hoard")
+        return home.joinpath("Library", "Application Support", "com.shadow53.hoard")
     elif system == 'Windows':
-        return home.join("AppData", "Roaming", "shadow53", "hoard", "data")
+        return home.joinpath("AppData", "Roaming", "shadow53", "hoard", "data")
     else:
         raise OSError("could not determine system for CI tests")
 
@@ -56,16 +56,16 @@ def setup():
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
             for num in [1, 2, 3]:
-                os.makedirs(home.join(f"{env}_{item}"), exist_ok=True)
-                with open(home.join("{env}_{item}", "{num}"), "wb") as file:
+                os.makedirs(home.joinpath(f"{env}_{item}"), exist_ok=True)
+                with open(home.joinpath(f"{env}_{item}", str(num)), "wb") as file:
                     content = secrets.token_bytes(num * 1024)
                     file.write(content)
         for item in ["anon_file", "named_file"]:
-            with open(home.join(f"{env}_{item}"), "wb") as file:
+            with open(home.joinpath(f"{env}_{item}"), "wb") as file:
                 content = secrets.token_bytes(2048)
                 file.write(content)
     os.makedirs(config_file_path().parent)
-    shutil.copy2(Path.cwd().join("ci-tests", "config.toml"), config_file_path())
+    shutil.copy2(Path.cwd().joinpath("ci-tests", "config.toml"), config_file_path())
 
 
 def assert_same_tree(path1, path2, *, direntries=None):
@@ -90,22 +90,22 @@ def assert_first_tree():
     home = Path.home()
     data_dir = data_dir_path()
     assert_same_tree(
-        home.join("first_anon_dir"),
-        data_dir.join("hoards", "anon_dir"),
+        home.joinpath("first_anon_dir"),
+        data_dir.joinpath("hoards", "anon_dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        home.join("first_anon_file"),
-        data_dir.join("hoards", "anon_file")
+        home.joinpath("first_anon_file"),
+        data_dir.joinpath("hoards", "anon_file")
     )
     assert_same_tree(
-        home.join("first_named_dir"),
-        data_dir.join("hoards", "named", "dir"),
+        home.joinpath("first_named_dir"),
+        data_dir.joinpath("hoards", "named", "dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        home.join("first_named_file"),
-        data_dir.join("hoards", "named", "file")
+        home.joinpath("first_named_file"),
+        data_dir.joinpath("hoards", "named", "file")
     )
 
 
@@ -113,22 +113,22 @@ def assert_second_tree():
     home = Path.home()
     data_dir = data_dir_path()
     assert_same_tree(
-        home.join("second_anon_dir"),
-        data_dir.join("hoards", "anon_dir"),
+        home.joinpath("second_anon_dir"),
+        data_dir.joinpath("hoards", "anon_dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        home.join("second_anon_file"),
-        data_dir.join("hoards", "anon_file")
+        home.joinpath("second_anon_file"),
+        data_dir.joinpath("hoards", "anon_file")
     )
     assert_same_tree(
-        home.join("second_named_dir"),
-        data_dir.join("hoards", "named", "dir"),
+        home.joinpath("second_named_dir"),
+        data_dir.joinpath("hoards", "named", "dir"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
-        home.join("second_named_file"),
-        data_dir.join("hoards", "named", "file")
+        home.joinpath("second_named_file"),
+        data_dir.joinpath("hoards", "named", "file")
     )
 
 

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -110,21 +110,21 @@ def test_last_paths():
     # Do setup
     setup()
     # Run hoard with env "first"
-    run_hoard("backup", env={"USE_ENV": "first"})
+    run_hoard("backup", env={"USE_ENV": "1"})
     # Doing it again should still succeed
-    run_hoard("backup", env={"USE_ENV": "first"})
+    run_hoard("backup", env={"USE_ENV": "1"})
     # Run hoard with env "second" - this should fail
     try:
-        run_hoard("backup", env={"USE_ENV": "second"})
+        run_hoard("backup", env={"USE_ENV": "2"})
         raise RuntimeError("Changing environment should have caused last_paths to fail")
     except subprocess.CalledProcessError:
         pass
     # Doing it again with "first" should still succeed
-    run_hoard("backup", env={"USE_ENV": "first"})
+    run_hoard("backup", env={"USE_ENV": "2"})
     # Make sure the files are consistent with backing up "first"
     assert_first_tree()
     # Doing it with "second" but forced should succeed
-    run_hoard("backup", env={"USE_ENV": "second"})
+    run_hoard("backup", env={"USE_ENV": "2"})
     # Make sure the files were overwritten
     assert_second_tree()
 

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -72,7 +72,7 @@ def setup():
     shutil.copy2("ci-tests/config.toml", config_file_path())
 
 
-def assert_same_tree(path1, path2, direntries=None):
+def assert_same_tree(path1, path2, *, direntries=None):
     if direntries is None:
         if not filecmp.cmp(path1, path2, shallow=False):
             raise RuntimeError(f"content of files {path1} and {path2} differ")
@@ -136,7 +136,7 @@ def assert_second_tree():
     )
 
 
-def run_hoard(command, force=False, targets=[], env=None):
+def run_hoard(command, *, force=False, targets=[], env=None):
     # Run the specified hoard command
     # Should automatically operate on all hoards when targets is empty
     for key, val in env.items():

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -103,7 +103,7 @@ def run_hoard(command, targets=[], env=None):
     # Should automatically operate on all hoards when targets is empty
     for key, val in env.items():
         os.environ[key] = val
-    subprocess.run(["target/debug/hoard", command, *targets], check=True)
+    subprocess.run(["target/debug/hoard", command, *targets], check=True, env=os.environ)
 
 
 def test_last_paths():

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -42,8 +42,12 @@ def data_dir_path():
 
 def setup():
     home = Path.home()
-    shutil.rmtree(data_dir_path())
-    shutil.rmtree(config_file_path().parent())
+    try:
+        shutil.rmtree(data_dir_path())
+        shutil.rmtree(config_file_path().parent())
+    except FileNotFoundError:
+        pass
+
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
             for file in [1, 2, 3]:

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -59,7 +59,7 @@ def setup():
 
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
-            for num in [1, 2, 3]:
+            for num in ["1", "2", "3"]:
                 os.makedirs(f"{home}/{env}_{item}", exist_ok=True)
                 with open(f"{home}/{env}_{item}/{num}", "wb") as file:
                     content = secrets.token_bytes(num * 1024)
@@ -96,7 +96,7 @@ def assert_first_tree():
     assert_same_tree(
         f"{home}/first_anon_dir",
         f"{data_dir}/hoards/anon_dir",
-        direntries=[1, 2, 3]
+        direntries=["1", "2", "3"]
     )
     assert_same_tree(
         f"{home}/first_anon_file",
@@ -105,7 +105,7 @@ def assert_first_tree():
     assert_same_tree(
         f"{home}/first_named_dir",
         f"{data_dir}/hoards/named/dir",
-        direntries=[1, 2, 3]
+        direntries=["1", "2", "3"]
     )
     assert_same_tree(
         f"{home}/first_named_file",
@@ -119,7 +119,7 @@ def assert_second_tree():
     assert_same_tree(
         f"{home}/second_anon_dir",
         f"{data_dir}/hoards/anon_dir",
-        direntries=[1, 2, 3]
+        direntries=["1", "2", "3"]
     )
     assert_same_tree(
         f"{home}/second_anon_file",
@@ -128,7 +128,7 @@ def assert_second_tree():
     assert_same_tree(
         f"{home}/second_named_dir",
         f"{data_dir}/hoards/named/dir",
-        direntries=[1, 2, 3]
+        direntries=["1", "2", "3"]
     )
     assert_same_tree(
         f"{home}/second_named_file",

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -42,8 +42,13 @@ def data_dir_path():
 
 def setup():
     home = Path.home()
+
     try:
         shutil.rmtree(data_dir_path())
+    except FileNotFoundError:
+        pass
+
+    try:
         shutil.rmtree(config_file_path().parent())
     except FileNotFoundError:
         pass
@@ -51,6 +56,7 @@ def setup():
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
             for file in [1, 2, 3]:
+                os.makedirs(f"{home}/{env}_{item}", exist_ok=True)
                 with open(f"{home}/{env}_{item}/{file}", "wb") as file:
                     content = secrets.token_bytes(file * 1024)
                     file.write(content)
@@ -58,6 +64,7 @@ def setup():
             with open(f"{home}/{env}_{item}", "wb") as file:
                 content = secrets.token_bytes(2048)
                 file.write(content)
+    os.makedirs(config_file_path().parent())
     shutil.copy2("ci-tests/config.toml", config_file_path())
 
 

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -55,10 +55,10 @@ def setup():
 
     for env in ["first", "second"]:
         for item in ["anon_dir", "named_dir"]:
-            for file in [1, 2, 3]:
+            for num in [1, 2, 3]:
                 os.makedirs(f"{home}/{env}_{item}", exist_ok=True)
-                with open(f"{home}/{env}_{item}/{file}", "wb") as file:
-                    content = secrets.token_bytes(file * 1024)
+                with open(f"{home}/{env}_{item}/{num}", "wb") as file:
+                    content = secrets.token_bytes(num * 1024)
                     file.write(content)
         for item in ["anon_file", "named_file"]:
             with open(f"{home}/{env}_{item}", "wb") as file:

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -49,7 +49,7 @@ def setup():
         pass
 
     try:
-        shutil.rmtree(config_file_path().parent())
+        shutil.rmtree(config_file_path().parent)
     except FileNotFoundError:
         pass
 
@@ -64,7 +64,7 @@ def setup():
             with open(f"{home}/{env}_{item}", "wb") as file:
                 content = secrets.token_bytes(2048)
                 file.write(content)
-    os.makedirs(config_file_path().parent())
+    os.makedirs(config_file_path().parent)
     shutil.copy2("ci-tests/config.toml", config_file_path())
 
 

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import filecmp
-import os.environ
+import os
 import platform
 import secrets
 import shutil

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
             test_last_paths()
         except Exception:
             print("\nHoards:")
-            subprocess.run(["tree", data_dir_path()])
+            subprocess.run(["tree", str(data_dir_path())])
             print("\nHome:")
-            subprocess.run(["tree", Path.home()])
+            subprocess.run(["tree", str(Path.home())])
             raise

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+import filecmp
+import os.environ
+import platform
+import secrets
+import shutil
+import subprocess
+import sys
+
+# Before continuing, ensure this is running on GitHub Actions
+for var in ["CI", "GITHUB_ACTIONS"]:
+    val = os.environ.get(var)
+    if val is None or val != "true":
+        raise RuntimeError("These tests must be run on GitHub Actions!")
+
+
+def config_file_path():
+    system = platform.system()
+    home = Path.home()
+    if system == 'Linux':
+        return Path(f"{home}/.config/hoard/config.toml")
+    elif system == 'Darwin':
+        return Path(f"{home}/Library/Application Support/com.shadow53.hoard/config.toml")
+    elif system == 'Windows':
+        return Path(f"{home}/AppData/Roaming/shadow53/hoard/config/config.toml")
+    else:
+        raise OSError("could not determine system for CI tests")
+
+
+def data_dir_path():
+    system = platform.system()
+    home = Path.home()
+    if system == 'Linux':
+        return Path(f"{home}/.local/share/hoard")
+    elif system == 'Darwin':
+        return Path(f"{home}/Library/Application Support/com.shadow53.hoard")
+    elif system == 'Windows':
+        return Path(f"{home}/AppData/Roaming/shadow53/hoard/data")
+    else:
+        raise OSError("could not determine system for CI tests")
+
+
+def setup():
+    home = Path.home()
+    shutil.rmtree(data_dir_path())
+    shutil.rmtree(config_file_path().parent())
+    for env in ["first", "second"]:
+        for item in ["anon_dir", "named_dir"]:
+            for file in [1, 2, 3]:
+                with open(f"{home}/{env}_{item}/{file}", "wb") as file:
+                    content = secrets.token_bytes(file * 1024)
+                    file.write(content)
+        for item in ["anon_file", "named_file"]:
+            with open(f"{home}/{env}_{item}", "wb") as file:
+                content = secrets.token_bytes(2048)
+                file.write(content)
+    shutil.copy2("ci-tests/config.toml", config_file_path())
+
+
+def assert_same_tree(path1, path2, direntries=None):
+    if direntries is None:
+        if not filecmp.cmp(path1, path2, shallow=False):
+            raise RuntimeError(f"content of files {path1} and {path2} differ")
+    else:
+        matches, mismatches, errors = filecmp.cmpfiles(path1, path2, direntries, shallow=False)
+        if errors:
+            raise RuntimeError(f"could not check {errors} inside {path1} and/or {path2}")
+        if mismatches:
+            raise RuntimeError(f"contents of files {mismatches} in {path1} and {path2} differ")
+
+
+def assert_first_tree():
+    home = Path.home()
+    data_dir = data_dir_path()
+    assert_same_tree(f"{home}/first_anon_dir", f"{data_dir}/hoards/anon_dir")
+    assert_same_tree(f"{home}/first_anon_file", f"{data_dir}/hoards/anon_file")
+    assert_same_tree(f"{home}/first_named_dir", f"{data_dir}/hoards/named/dir")
+    assert_same_tree(f"{home}/first_named_file", f"{data_dir}/hoards/named/file")
+
+
+def assert_second_tree():
+    home = Path.home()
+    data_dir = data_dir_path()
+    assert_same_tree(f"{home}/second_anon_dir", f"{data_dir}/hoards/anon_dir")
+    assert_same_tree(f"{home}/second_anon_file", f"{data_dir}/hoards/anon_file")
+    assert_same_tree(f"{home}/second_named_dir", f"{data_dir}/hoards/named/dir")
+    assert_same_tree(f"{home}/second_named_file", f"{data_dir}/hoards/named/file")
+
+
+def run_hoard(command, targets=[], env=None):
+    # Run the specified hoard command
+    # Should automatically operate on all hoards when targets is empty
+    subprocess.run("target/debug/hoard", command, *targets, check=True, env=env)
+
+
+def test_last_paths():
+    # Do setup
+    setup()
+    # Run hoard with env "first"
+    run_hoard("backup", env={"USE_ENV": "first"})
+    # Doing it again should still succeed
+    run_hoard("backup", env={"USE_ENV": "first"})
+    # Run hoard with env "second" - this should fail
+    try:
+        run_hoard("backup", env={"USE_ENV": "second"})
+        raise RuntimeError("Changing environment should have caused last_paths to fail")
+    except subprocess.CalledProcessError:
+        pass
+    # Doing it again with "first" should still succeed
+    run_hoard("backup", env={"USE_ENV": "first"})
+    # Make sure the files are consistent with backing up "first"
+    assert_first_tree()
+    # Doing it with "second" but forced should succeed
+    run_hoard("backup", env={"USE_ENV": "second"})
+    # Make sure the files were overwritten
+    assert_second_tree()
+
+
+if __name__ == "__main__":
+    if len(sys.args) == 1:
+        raise RuntimeError("One argument - the test - is required")
+    if sys.args[1] == "last_paths":
+        test_last_paths()

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -117,7 +117,7 @@ def test_last_paths():
 
 
 if __name__ == "__main__":
-    if len(sys.args) == 1:
+    if len(sys.argv) == 1:
         raise RuntimeError("One argument - the test - is required")
-    if sys.args[1] == "last_paths":
+    if sys.argv[1] == "last_paths":
         test_last_paths()

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -101,7 +101,7 @@ def assert_second_tree():
 def run_hoard(command, targets=[], env=None):
     # Run the specified hoard command
     # Should automatically operate on all hoards when targets is empty
-    subprocess.run("target/debug/hoard", command, *targets, check=True, env=env)
+    subprocess.run(["target/debug/hoard", command, *targets], check=True, env=env)
 
 
 def test_last_paths():

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -98,11 +98,13 @@ def assert_second_tree():
     assert_same_tree(f"{home}/second_named_file", f"{data_dir}/hoards/named/file")
 
 
-def run_hoard(command, targets=[], env=None):
+def run_hoard(command, force=False, targets=[], env=None):
     # Run the specified hoard command
     # Should automatically operate on all hoards when targets is empty
     for key, val in env.items():
         os.environ[key] = val
+    if force:
+        targets.insert(0, "--force")
     subprocess.run(["target/debug/hoard", command, *targets], check=True)
 
 
@@ -120,11 +122,11 @@ def test_last_paths():
     except subprocess.CalledProcessError:
         pass
     # Doing it again with "first" should still succeed
-    run_hoard("backup", env={"USE_ENV": "2"})
+    run_hoard("backup", env={"USE_ENV": "1"})
     # Make sure the files are consistent with backing up "first"
     assert_first_tree()
     # Doing it with "second" but forced should succeed
-    run_hoard("backup", env={"USE_ENV": "2"})
+    run_hoard("backup", force=True, env={"USE_ENV": "2"})
     # Make sure the files were overwritten
     assert_second_tree()
 

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -141,9 +141,13 @@ def run_hoard(command, force=False, targets=[], env=None):
     # Should automatically operate on all hoards when targets is empty
     for key, val in env.items():
         os.environ[key] = val
+
+    args = ["target/debug/hoard"]
     if force:
-        targets.insert(0, "--force")
-    subprocess.run(["target/debug/hoard", command, *targets], check=True)
+        args.append("--force")
+    args += targets
+
+    subprocess.run(args, check=True)
 
 
 def test_last_paths():

--- a/src/checkers/history/last_paths.rs
+++ b/src/checkers/history/last_paths.rs
@@ -363,20 +363,15 @@ mod tests {
     }
 
     #[test]
-    fn new_lastpaths_is_empty() {
-        let last_paths = LastPaths::new();
+    fn default_lastpaths_is_empty() {
+        let last_paths = LastPaths::default();
         assert_eq!(last_paths.0.len(), 0);
-    }
-
-    #[test]
-    fn last_paths_new_is_default() {
-        assert_eq!(LastPaths::new(), LastPaths::default());
     }
 
     #[test]
     fn test_lastpaths_get_set_hoard() {
         let hoard_paths = anonymous_hoard_paths();
-        let mut last_paths = LastPaths::new();
+        let mut last_paths = LastPaths::default();
         let key = "testkey";
         last_paths.set_hoard(key.to_string(), hoard_paths.clone());
         let got_hoard_paths = last_paths.hoard(key);

--- a/src/checkers/history/last_paths.rs
+++ b/src/checkers/history/last_paths.rs
@@ -59,8 +59,7 @@ impl Checker for LastPaths {
 
     fn check(&mut self) -> Result<(), Self::Error> {
         let _span = tracing::debug_span!("running last_paths check", current=?self).entered();
-        let (name, new_hoard) = self.0.iter().next()
-            .ok_or(Error::NoEntries)?;
+        let (name, new_hoard) = self.0.iter().next().ok_or(Error::NoEntries)?;
 
         let last_paths = LastPaths::from_default_file()?;
         if let Some(old_hoard) = last_paths.hoard(name) {

--- a/src/checkers/history/last_paths.rs
+++ b/src/checkers/history/last_paths.rs
@@ -170,8 +170,8 @@ impl From<HashMap<String, PathBuf>> for PilePaths {
 impl From<Hoard> for PilePaths {
     fn from(other: Hoard) -> Self {
         match other {
-            Hoard::Single(pile) => PilePaths::Anonymous(pile.path),
-            Hoard::Multiple(named) => PilePaths::Named(
+            Hoard::Anonymous(pile) => PilePaths::Anonymous(pile.path),
+            Hoard::Named(named) => PilePaths::Named(
                 named
                     .piles
                     .into_iter()

--- a/src/checkers/history/last_paths.rs
+++ b/src/checkers/history/last_paths.rs
@@ -4,8 +4,8 @@
 //! See the documentation for [`HoardPaths::enforce_old_and_new_piles_are_same`] for an
 //! explanation of why this is useful.
 
-use crate::config::hoard::Hoard;
 use super::super::Checker;
+use crate::config::hoard::Hoard;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -172,9 +172,11 @@ impl From<Hoard> for PilePaths {
         match other {
             Hoard::Single(pile) => PilePaths::Anonymous(pile.path),
             Hoard::Multiple(named) => PilePaths::Named(
-                named.piles.into_iter()
-                .filter_map(|(key, pile)| pile.path.map(|path| (key, path)))
-                .collect()
+                named
+                    .piles
+                    .into_iter()
+                    .filter_map(|(key, pile)| pile.path.map(|path| (key, path)))
+                    .collect(),
             ),
         }
     }

--- a/src/checkers/history/mod.rs
+++ b/src/checkers/history/mod.rs
@@ -10,6 +10,7 @@ use std::{fs, io};
 use uuid::Uuid;
 
 pub mod last_paths;
+pub mod operation;
 
 const UUID_FILE_NAME: &str = "uuid";
 const HISTORY_DIR_NAME: &str = "history";

--- a/src/checkers/history/mod.rs
+++ b/src/checkers/history/mod.rs
@@ -48,9 +48,9 @@ fn get_history_dirs_not_for_id(id: &Uuid) -> Result<Vec<PathBuf>, io::Error> {
                         file_name.to_str().and_then(|file_str| {
                             // Only directories that have UUIDs for names and do not match "this"
                             // id.
-                            Uuid::parse_str(file_str).ok().and_then(|other_id| {
-                                (&other_id != id).then(|| Ok(path.clone()))
-                            })
+                            Uuid::parse_str(file_str)
+                                .ok()
+                                .and_then(|other_id| (&other_id != id).then(|| Ok(path.clone())))
                         })
                     })
                 }

--- a/src/checkers/history/mod.rs
+++ b/src/checkers/history/mod.rs
@@ -1,8 +1,5 @@
 //! Keep records of previous operations (including on other system) to prevent inconsistencies
 //! and accidental overwrites or deletions.
-//!
-//! This module currently focuses on the [`last_paths`] submodule, which gives a warning and
-//! aborts an operation if the paths being used differ from the previous operation.
 
 use crate::config::get_dirs;
 use std::path::PathBuf;

--- a/src/checkers/history/operation.rs
+++ b/src/checkers/history/operation.rs
@@ -142,7 +142,7 @@ impl HoardOperation {
         result
     }
 
-    /// Create a new `Operation` from the given hoards mappings and map of last logs.
+    /// Create a new `Operation` from the given hoard.
     ///
     /// # Errors
     ///

--- a/src/checkers/history/operation.rs
+++ b/src/checkers/history/operation.rs
@@ -1,0 +1,185 @@
+//! Keeping track of all operations.
+//!
+//! The types in this module are used for logging all operations to disk. This information can be
+//! used for debugging purposes, but is more directly used as a [`Checker`] to help prevent
+//! synchronized changes from being overwritten.
+//!
+//! It does this by parsing synchronized logs from this and other systems to determine which system
+//! was the last one to touch a file.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::DirEntry;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+use thiserror::Error;
+use uuid::Uuid;
+
+static LOG_FILE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new("^([0-9]{2}_){2}([0-9]{2}-[0-9]{2}_){2}([0-9]{2}).log$")
+        .expect("invalid log file regex")
+});
+
+/// Errors that may occur while working with operation logs.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Any I/O error.
+    #[error("an I/O error occurred: {0}")]
+    IO(#[from] io::Error),
+    /// An error occurred while (de)serializing with `serde`.
+    #[error("a (de)serialization error occurred: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// A single operation log.
+///
+/// This keeps track of the timestamp of the operation (which may include multiple hoards),
+/// all hoards involved in the operation (and the related [`HoardOperation`]), and a record
+/// of the latest operation log for each external system at the time of invocation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Operation {
+    /// Timestamp of last operation
+    timestamp: chrono::DateTime<chrono::Utc>,
+    /// Maps name of hoard to mapping of files to their checksums
+    hoards: HashMap<String, Hoard>,
+    /// Maps UUID of device to name of previous log file
+    last_logs: HashMap<Uuid, String>,
+}
+
+/// Operation log information for a single hoard.
+///
+/// Really just a wrapper for [`PileOperation`] because piles may be anonymous or named.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Hoard {
+    /// Information for a single, anonymous pile.
+    Anonymous(Pile),
+    /// Information for some number of named piles.
+    Named(HashMap<String, Pile>),
+}
+
+/// Enum to differentiate between different types of checksum.
+///
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Checksum {
+    /// An MD5 checksum. Fast but may have collisions.
+    MD5(String),
+}
+
+/// A mapping of file path (relative to pile) to file checksum.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Pile(HashMap<PathBuf, String>);
+
+impl Operation {
+    fn file_is_log(path: &Path) -> bool {
+        path.is_file()
+            && match path.file_name() {
+                None => false,
+                Some(name) => match name.to_str() {
+                    None => false,
+                    Some(name) => LOG_FILE_REGEX.is_match(name),
+                },
+            }
+    }
+
+    /// Create a new `Operation` from the given hoards mappings and map of last logs.
+    #[must_use]
+    pub fn new(hoards: HashMap<String, Hoard>, last_logs: HashMap<Uuid, String>) -> Self {
+        Self {
+            timestamp: chrono::Utc::now(),
+            hoards,
+            last_logs,
+        }
+    }
+
+    /// Returns the latest operation recorded on this machine (by UUID).
+    ///
+    /// # Errors
+    ///
+    /// - Any errors that occur while reading from the filesystem
+    /// - Any parsing errors from `serde_json` when parsing the file
+    pub fn latest() -> Result<Option<Self>, Error> {
+        tracing::debug!("finding latest Operation file for this machine");
+        let uuid = super::get_or_generate_uuid()?;
+        let self_folder = super::get_history_dir_for_id(uuid);
+        let latest_file = self_folder
+            .read_dir()?
+            .filter_map(|item| {
+                // Only keep errors and anything where path() returns Some
+                item.map(|item| {
+                    let path = item.path();
+                    Self::file_is_log(&path).then(|| path)
+                })
+                .transpose()
+            })
+            .reduce(|acc, item| {
+                let acc = acc?;
+                let item = item?;
+                if acc.file_name() > item.file_name() {
+                    Ok(acc)
+                } else {
+                    Ok(item)
+                }
+            })
+            .transpose()?;
+
+        latest_file
+            .map(|entry| fs::File::open(entry).map(serde_json::from_reader))
+            .transpose()?
+            .transpose()
+            .map_err(Error::Serde)
+    }
+
+    /// Returns a sorted list of all unseen operations since this one happened.
+    ///
+    /// # Errors
+    ///
+    /// - Any I/O errors that occur while reading log files.
+    /// - Any `serde` errors that occur while parsing log files.
+    pub fn all_unseen_operations_since(&self) -> Result<Vec<Operation>, Error> {
+        //
+        let _span = tracing::debug_span!("loading unseen operation logs", since=%self.timestamp.format("%F %T")).entered();
+        let root = super::get_history_root_dir();
+        let mut result_vec = Vec::new();
+        for result in root.read_dir()? {
+            let entry = result?;
+            if let Ok(id) = entry.file_name().to_string_lossy().parse::<Uuid>() {
+                // Found a remote system log dir
+                tracing::debug!("checking logs for system: {}", id);
+                let _span = tracing::trace_span!("checking_logs", %id).entered();
+
+                let last_log = self.last_logs.get(&id);
+                let last_log_os = last_log.as_ref().map(std::ffi::OsString::from);
+
+                tracing::trace!("getting all unseen entries based on file name");
+                let mut entries: Vec<DirEntry> = entry
+                    .path()
+                    .read_dir()?
+                    .filter_map(Result::ok)
+                    .filter(|item| Self::file_is_log(&item.path()))
+                    .filter(|item| match &last_log_os {
+                        None => true,
+                        Some(file) => &item.file_name() > file,
+                    })
+                    .collect();
+
+                // Order of items read with read_dir is not guaranteed to be sorted.
+                tracing::trace!("sorting entries by file name");
+                entries.sort_by_key(fs::DirEntry::file_name);
+
+                result_vec.append(&mut entries);
+            }
+        }
+
+        tracing::trace!("parsing all unseen logs");
+        result_vec
+            .into_iter()
+            .map(|entry| {
+                let file = fs::File::open(entry.path())?;
+                Ok(serde_json::from_reader(file)?)
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+}

--- a/src/checkers/history/operation.rs
+++ b/src/checkers/history/operation.rs
@@ -70,7 +70,8 @@ impl Checker for HoardOperation {
     }
 
     fn check(&mut self) -> Result<(), Self::Error> {
-        let _span = tracing::debug_span!("is_pending_operation_valid", hoard=%self.hoard_name).entered();
+        let _span =
+            tracing::debug_span!("is_pending_operation_valid", hoard=%self.hoard_name).entered();
         tracing::debug!("checking if the hoard operation is safe to perform");
         let last_local = Self::latest_local(&self.hoard_name)?;
         let last_remote = Self::latest_remote_backup(&self.hoard_name)?;
@@ -111,7 +112,8 @@ impl Checker for HoardOperation {
     }
 
     fn commit_to_disk(self) -> Result<(), Self::Error> {
-        let _span = tracing::trace_span!("commit_operation_to_disk", hoard=%self.hoard_name).entered();
+        let _span =
+            tracing::trace_span!("commit_operation_to_disk", hoard=%self.hoard_name).entered();
         let id = super::get_or_generate_uuid()?;
         let path = super::get_history_dir_for_id(id)
             .join(&self.hoard_name)
@@ -145,7 +147,9 @@ impl HoardOperation {
     ///
     /// Returns [`Error::RestoreRequired`] if they do not have the same files (and hashes).
     pub fn check_has_same_files(&self, other: &Self) -> Result<(), Error> {
-        (self.hoard == other.hoard).then(|| ()).ok_or(Error::RestoreRequired)
+        (self.hoard == other.hoard)
+            .then(|| ())
+            .ok_or(Error::RestoreRequired)
     }
 
     /// Returns the latest operation for the given hoard from a system history root directory.
@@ -316,4 +320,3 @@ impl TryFrom<&ConfigPile> for Pile {
         )
     }
 }
-

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -15,7 +15,7 @@ pub trait Checker {
     /// The error type returned from the check.
     type Error: std::error::Error;
     /// Returns an error if it is not safe to operate on the given [`Hoard`].
-    /// 
+    ///
     /// # Errors
     ///
     /// Any error that prevents operations on the given [`Hoard`], or any errors that

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -1,0 +1,24 @@
+//! Types that validate (check) Hoard configurations
+//!
+//! This module includes a single trait, [`Checker`], and all types that implement it.
+//! Currently, that is only the [`LastPaths`](history::last_paths::LastPaths) checker.
+
+pub mod history;
+
+use crate::config::hoard::Hoard;
+
+/// Trait for validating [`Hoard`]s.
+///
+/// A [`Checker`] takes a [`Hoard`] and its name (as [`&str`]) as parameters and uses that
+/// information plus any internal state to validate that it is safe to operate on that [`Hoard`].
+pub trait Checker {
+    /// The error type returned from the check.
+    type Error: std::error::Error;
+    /// Returns an error if it is not safe to operate on the given [`Hoard`].
+    /// 
+    /// # Errors
+    ///
+    /// Any error that prevents operations on the given [`Hoard`], or any errors that
+    /// occur while performing the check.
+    fn check(&mut self, name: &str, hoard: &Hoard) -> Result<(), Self::Error>;
+}

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -11,14 +11,26 @@ use crate::config::hoard::Hoard;
 ///
 /// A [`Checker`] takes a [`Hoard`] and its name (as [`&str`]) as parameters and uses that
 /// information plus any internal state to validate that it is safe to operate on that [`Hoard`].
-pub trait Checker {
+pub trait Checker: Sized {
     /// The error type returned from the check.
     type Error: std::error::Error;
+    /// Returns a new instance of the implementing Checker type.
+    ///
+    /// # Errors
+    ///
+    /// Any errors that may occur while creating an instance, such as I/O or consistency errors.
+    fn new(name: &str, hoard: &Hoard, is_backup: bool) -> Result<Self, Self::Error>;
     /// Returns an error if it is not safe to operate on the given [`Hoard`].
     ///
     /// # Errors
     ///
     /// Any error that prevents operations on the given [`Hoard`], or any errors that
     /// occur while performing the check.
-    fn check(&mut self, name: &str, hoard: &Hoard) -> Result<(), Self::Error>;
+    fn check(&mut self) -> Result<(), Self::Error>;
+    /// Saves any persistent data to disk.
+    ///
+    /// # Errors
+    ///
+    /// Generally, any I/O errors that occur while persisting data.
+    fn commit_to_disk(self) -> Result<(), Self::Error>;
 }

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -271,9 +271,9 @@ mod tests {
         ];
 
         for (expected, input) in test_params {
+            let result: bool = input.clone().try_into().unwrap();
             assert_eq!(
-                expected,
-                input.clone().try_into().unwrap(),
+                result, expected,
                 "CombinatorInner did not AND items correctly: {:?}",
                 input
             );
@@ -485,9 +485,9 @@ mod tests {
     #[test]
     fn test_combinator() {
         for case in CASES.iter() {
+            let result: bool = case.combinator.clone().try_into().unwrap();
             assert_eq!(
-                case.evaluates_to,
-                case.combinator.clone().try_into().unwrap(),
+                result, case.evaluates_to,
                 "Combinator did not OR items correctly: {:?}",
                 case.combinator
             );

--- a/src/config/builder/environment/exe.rs
+++ b/src/config/builder/environment/exe.rs
@@ -61,7 +61,7 @@ mod tests {
                 .try_into()
                 .expect("failed to check if exe exists");
 
-            assert!(exists)
+            assert!(exists, "exe {} should exist", exe);
         }
     }
 

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -175,7 +175,7 @@ impl Node {
 
         // Default evaluation if subtree does not exist
         let mut eval = Evaluation {
-            name: self.name.clone(),
+            name: String::new(),
             path: self.value.as_deref(),
             scores: vec![],
         };
@@ -234,7 +234,11 @@ impl Node {
             }
         }
 
-        // Found best match, add self score
+        if eval.name.is_empty() {
+            eval.name = self.name.clone();
+        } else {
+            eval.name = format!("{}|{}", self.name, eval.name);
+        }
         eval.scores.push(self.score);
         // Sort largest values first
         eval.scores.sort_unstable_by(|left, right| right.cmp(left));
@@ -381,7 +385,7 @@ impl EnvTrie {
         let exclusivity_map = get_exclusivity_map(exclusive_list);
 
         // Building a list of linked lists that represent paths from the root of a tree to a leaf.
-        tracing::trace!("building trees for each environment string");
+        tracing::trace!(?exclusivity_map, ?weighted_map, "building trees for each environment string");
         let trees: Vec<_> = environments
             .iter()
             .map(|(env_str, path)| {
@@ -405,7 +409,7 @@ impl EnvTrie {
                 // Last node, then building up to the root.
                 let mut prev_node = Node {
                     name: String::new(),
-                    score: 1,
+                    score: 0,
                     tree: None,
                     value: Some(path.clone()),
                 };

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -1,6 +1,5 @@
 //! Notes
 //! - Length of matching path takes precedence over the strength of any one segment.
-//! - If two paths have the same length and score, the first one is taken.
 //! - Weights of each segment are determined by taking sets of mutually exclusive
 //!   segments and creating a DAG to determine weights.
 //! - No current design for making a short path win out over a longer one.
@@ -320,7 +319,7 @@ fn get_weighted_map(exclusive_list: &[Vec<String>]) -> Result<BTreeMap<String, u
             // suffices as relative weight
             v.into_iter()
                 .enumerate()
-                .map(|(i, id)| (score_dag[id].clone(), i))
+                .map(|(i, id)| (score_dag[id].clone(), i + 1))
                 .collect()
         })
         .map_err(|cycle| {
@@ -419,7 +418,7 @@ impl EnvTrie {
                 for segment in envs.into_iter().rev() {
                     let segment = segment.to_string();
 
-                    let score = weighted_map.get(&segment).copied().unwrap_or(1);
+                    prev_node.score = weighted_map.get(&segment).copied().unwrap_or(1);
                     prev_node.name = segment.clone();
                     let tree = {
                         let mut tree = BTreeMap::new();
@@ -428,7 +427,7 @@ impl EnvTrie {
                     };
 
                     prev_node = Node {
-                        score,
+                        score: 0,
                         tree,
                         value: None,
                         name: String::new(),

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -488,7 +488,6 @@ impl EnvTrie {
 mod tests {
     use super::*;
     use maplit::btreemap;
-    use once_cell::sync::Lazy;
     use std::collections::BTreeMap;
 
     // Every const has a name of the form `LABEL_<char>_<int>`.
@@ -502,9 +501,9 @@ mod tests {
     const LABEL_C_1: &str = "c1";
     const LABEL_C_2: &str = "c2";
 
-    static PATH_1: Lazy<String> = Lazy::new(|| String::from("/tmp/path1"));
-    static PATH_2: Lazy<String> = Lazy::new(|| String::from("/tmp/path2"));
-    static PATH_3: Lazy<String> = Lazy::new(|| String::from("/tmp/path3"));
+    const PATH_1: &str = "/tmp/path1";
+    const PATH_2: &str = "/tmp/path2";
+    const PATH_3: &str = "/tmp/path3";
 
     fn node_eq_ignore_score(trie: &Node, expected: &Node) -> bool {
         if trie.value != expected.value {
@@ -567,9 +566,9 @@ mod tests {
     trie_test_ignore_score! {
         name: test_valid_single_env,
         environments: btreemap! {
-            LABEL_A_1.into() => PATH_1.clone(),
-            LABEL_B_1.into() => PATH_2.clone(),
-            LABEL_C_1.into() => PATH_3.clone(),
+            LABEL_A_1.into() => PATH_1.into(),
+            LABEL_B_1.into() => PATH_2.into(),
+            LABEL_C_1.into() => PATH_3.into(),
         },
         exclusivity: vec![],
         expected: {
@@ -582,19 +581,19 @@ mod tests {
                         name: LABEL_A_1.to_owned(),
                         score: 1,
                         tree: None,
-                        value: Some(PATH_1.clone()),
+                        value: Some(PATH_1.into()),
                     },
                     LABEL_B_1.to_owned() => Node {
                         name: LABEL_B_1.to_owned(),
                         score: 1,
                         tree: None,
-                        value: Some(PATH_2.clone()),
+                        value: Some(PATH_2.into()),
                     },
                     LABEL_C_1.to_owned() => Node {
                         name: LABEL_C_1.to_owned(),
                         score: 1,
                         tree: None,
-                        value: Some(PATH_3.clone()),
+                        value: Some(PATH_3.into()),
                     },
                 })
             };
@@ -605,13 +604,13 @@ mod tests {
     trie_test_ignore_score! {
         name: test_valid_multi_env,
         environments: btreemap! {
-            format!("{}|{}|{}", LABEL_A_1, LABEL_B_1, LABEL_C_1) => PATH_1.clone(),
+            format!("{}|{}|{}", LABEL_A_1, LABEL_B_1, LABEL_C_1) => PATH_1.into(),
             // Testing merged trees
-            format!("{}|{}|{}", LABEL_A_1, LABEL_B_2, LABEL_C_1) => PATH_2.clone(),
+            format!("{}|{}|{}", LABEL_A_1, LABEL_B_2, LABEL_C_1) => PATH_2.into(),
             // The generated tree should be in sorted order
-            format!("{}|{}|{}", LABEL_B_3, LABEL_A_3, LABEL_C_2) => PATH_3.clone(),
+            format!("{}|{}|{}", LABEL_B_3, LABEL_A_3, LABEL_C_2) => PATH_3.into(),
             // Testing overlapping trees
-            format!("{}|{}", LABEL_A_3, LABEL_B_3) => PATH_2.clone(),
+            format!("{}|{}", LABEL_A_3, LABEL_B_3) => PATH_2.into(),
         },
         exclusivity: vec![
             vec![LABEL_A_1.into(), LABEL_A_2.into(), LABEL_A_3.into()],
@@ -638,7 +637,7 @@ mod tests {
                                         name: LABEL_C_1.to_owned(),
                                         score: 1,
                                         tree: None,
-                                        value: Some(PATH_1.clone()),
+                                        value: Some(PATH_1.into()),
                                     }
                                 })
                             },
@@ -651,7 +650,7 @@ mod tests {
                                         name: LABEL_C_1.to_owned(),
                                         score: 1,
                                         tree: None,
-                                        value: Some(PATH_2.clone())
+                                        value: Some(PATH_2.into())
                                     }
                                 })
                             }
@@ -665,13 +664,13 @@ mod tests {
                             LABEL_B_3.into() => Node {
                                 name: LABEL_B_3.to_owned(),
                                 score: 1,
-                                value: Some(PATH_2.clone()),
+                                value: Some(PATH_2.into()),
                                 tree: Some(btreemap! {
                                     LABEL_C_2.into() => Node {
                                         name: LABEL_C_2.to_owned(),
                                         score: 1,
                                         tree: None,
-                                        value: Some(PATH_3.clone()),
+                                        value: Some(PATH_3.into()),
                                     }
                                 })
                             }
@@ -687,7 +686,7 @@ mod tests {
     trie_test_ignore_score! {
         name: test_invalid_separator_prefix,
         environments: btreemap! {
-            format!("|{}|{}", LABEL_A_1, LABEL_B_1) => PATH_1.clone(),
+            format!("|{}|{}", LABEL_A_1, LABEL_B_1) => PATH_1.into(),
         },
         exclusivity: vec![],
         expected: Err(Error::EmptyEnvironment(format!("|{}|{}", LABEL_A_1, LABEL_B_1)))
@@ -696,7 +695,7 @@ mod tests {
     trie_test_ignore_score! {
         name: test_invalid_separator_suffix,
         environments: btreemap! {
-            format!("{}|{}|", LABEL_A_1, LABEL_B_1) => PATH_1.clone(),
+            format!("{}|{}|", LABEL_A_1, LABEL_B_1) => PATH_1.into(),
         },
         exclusivity: vec![],
         expected: Err(Error::EmptyEnvironment(format!("{}|{}|", LABEL_A_1, LABEL_B_1)))
@@ -705,7 +704,7 @@ mod tests {
     trie_test_ignore_score! {
         name: test_invalid_consecutive_separator,
         environments: btreemap! {
-            format!("{}||{}", LABEL_A_1, LABEL_B_1) => PATH_1.clone(),
+            format!("{}||{}", LABEL_A_1, LABEL_B_1) => PATH_1.into(),
         },
         exclusivity: vec![],
         expected: Err(Error::EmptyEnvironment(format!("{}||{}", LABEL_A_1, LABEL_B_1)))
@@ -714,7 +713,7 @@ mod tests {
     trie_test_ignore_score! {
         name: test_combine_mutually_exclusive_is_invalid,
         environments: btreemap! {
-            format!("{}|{}", LABEL_A_1, LABEL_A_2) => PATH_1.clone(),
+            format!("{}|{}", LABEL_A_1, LABEL_A_2) => PATH_1.into(),
         },
         exclusivity: vec![vec![LABEL_A_1.into(), LABEL_A_2.into()]],
         expected: Err(Error::CombinedMutuallyExclusive(format!("{}|{}", LABEL_A_1, LABEL_A_2)))
@@ -723,17 +722,17 @@ mod tests {
     trie_test_ignore_score! {
         name: test_same_condition_twice_is_invalid,
         environments: btreemap! {
-            format!("{}|{}", LABEL_A_1, LABEL_B_1) => PATH_1.clone(),
-            format!("{}|{}", LABEL_B_1, LABEL_A_1) => PATH_2.clone(),
+            format!("{}|{}", LABEL_A_1, LABEL_B_1) => PATH_1.into(),
+            format!("{}|{}", LABEL_B_1, LABEL_A_1) => PATH_2.into(),
         },
         exclusivity: vec![],
-        expected: Err(Error::DoubleDefine(PATH_1.clone(), PATH_2.clone()))
+        expected: Err(Error::DoubleDefine(PATH_1.into(), PATH_2.into()))
     }
 
     trie_test_ignore_score! {
         name: test_empty_condition_is_invalid,
         environments: btreemap! {
-            "".into() => PATH_1.clone(),
+            "".into() => PATH_1.into(),
         },
         exclusivity: vec![],
         expected: Err(Error::NoEnvironments)

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -87,42 +87,42 @@ struct Evaluation<'a> {
     scores: Vec<usize>,
 }
 
-impl <'a> Evaluation<'a> {
+impl<'a> Evaluation<'a> {
     fn is_better_match_than(&self, other: &Evaluation<'a>) -> Result<bool, Error> {
         match (self.path, other.path) {
             (_, None) => Ok(true),
             (None, Some(_)) => Ok(false),
-            (Some(_), Some(_)) => {
-                match self.scores.len().cmp(&other.scores.len()) {
-                    std::cmp::Ordering::Less => Ok(false),
-                    std::cmp::Ordering::Greater => Ok(true),
-                    std::cmp::Ordering::Equal => {
-                        let rel_score: i32 = self.scores.iter()
-                            .zip(other.scores.iter())
-                            .map(|(s, o)| match s.cmp(o) {
-                                std::cmp::Ordering::Less => -1,
-                                std::cmp::Ordering::Equal => 0,
-                                std::cmp::Ordering::Greater => 1,
-                            })
-                            .sum();
+            (Some(_), Some(_)) => match self.scores.len().cmp(&other.scores.len()) {
+                std::cmp::Ordering::Less => Ok(false),
+                std::cmp::Ordering::Greater => Ok(true),
+                std::cmp::Ordering::Equal => {
+                    let rel_score: i32 = self
+                        .scores
+                        .iter()
+                        .zip(other.scores.iter())
+                        .map(|(s, o)| match s.cmp(o) {
+                            std::cmp::Ordering::Less => -1,
+                            std::cmp::Ordering::Equal => 0,
+                            std::cmp::Ordering::Greater => 1,
+                        })
+                        .sum();
 
-                        match rel_score.cmp(&0) {
-                            std::cmp::Ordering::Less => Ok(false),
-                            std::cmp::Ordering::Greater => Ok(true),
-                            std::cmp::Ordering::Equal => {
-                                tracing::error!(
-                                    left_eval = ?self,
-                                    right_eval = ?other,
-                                    "cannot choose between {} and {}",
-                                    self.name,
-                                    other.name
-                                );
-                                Err(Error::Indecision(self.name.clone(), other.name.clone()))
-                            },
+                    match rel_score.cmp(&0) {
+                        std::cmp::Ordering::Less => Ok(false),
+                        std::cmp::Ordering::Greater => Ok(true),
+                        std::cmp::Ordering::Equal => {
+                            tracing::error!(
+                                left_eval = ?self,
+                                right_eval = ?other,
+                                "cannot choose between {} and {}",
+                                self.name,
+                                other.name
+                            );
+                            Err(Error::Indecision(self.name.clone(), other.name.clone()))
                         }
-                    },
+                    }
                 }
-            }
+            },
         }
     }
 }

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -9,10 +9,9 @@
 //! used.
 
 use crate::config::builder::envtrie::{EnvTrie, Error as TrieError};
-use crate::env_vars::expand_env_in_path;
+use crate::env_vars::{expand_env_in_path, Error as EnvError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::env::VarError;
 use std::path::Path;
 use thiserror::Error;
 
@@ -34,7 +33,7 @@ pub enum Error {
         path: String,
         /// The original error.
         #[source]
-        error: VarError,
+        error: EnvError,
     },
 }
 

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -149,7 +149,9 @@ impl Hoard {
         match self {
             Hoard::Single(single) => {
                 tracing::debug!("processing anonymous pile");
-                Ok(ConfigHoard::Anonymous(single.process_with(envs, exclusivity)?))
+                Ok(ConfigHoard::Anonymous(
+                    single.process_with(envs, exclusivity)?,
+                ))
             }
             Hoard::Multiple(multiple) => {
                 tracing::debug!("processing named pile(s)");

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -149,11 +149,11 @@ impl Hoard {
         match self {
             Hoard::Single(single) => {
                 tracing::debug!("processing anonymous pile");
-                Ok(ConfigHoard::Single(single.process_with(envs, exclusivity)?))
+                Ok(ConfigHoard::Anonymous(single.process_with(envs, exclusivity)?))
             }
             Hoard::Multiple(multiple) => {
                 tracing::debug!("processing named pile(s)");
-                Ok(ConfigHoard::Multiple(
+                Ok(ConfigHoard::Named(
                     multiple.process_with(envs, exclusivity)?,
                 ))
             }

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -87,9 +87,7 @@ impl Pile {
 
         let Pile { config, items } = self;
         let trie = EnvTrie::new(&items, exclusivity)?;
-        let path = trie.get_path(envs)?
-            .map(expand_env_in_path)
-            .transpose()?;
+        let path = trie.get_path(envs)?.map(expand_env_in_path).transpose()?;
 
         Ok(ConfigSingle { config, path })
     }

--- a/src/config/builder/mod.rs
+++ b/src/config/builder/mod.rs
@@ -1,6 +1,6 @@
 //! The [`Builder`] struct serves as an intermediate step between raw configuration and the
 //! [`Config`] type that is used by `hoard`.
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -47,7 +47,7 @@ pub enum Error {
 pub struct Builder {
     #[structopt(skip)]
     #[serde(rename = "envs")]
-    environments: Option<BTreeMap<String, Environment>>,
+    environments: Option<HashMap<String, Environment>>,
     #[structopt(skip)]
     exclusivity: Option<Vec<Vec<String>>>,
     #[structopt(short, long)]
@@ -62,7 +62,7 @@ pub struct Builder {
     #[structopt(short, long)]
     force: bool,
     #[structopt(skip)]
-    hoards: Option<BTreeMap<String, Hoard>>,
+    hoards: Option<HashMap<String, Hoard>>,
 }
 
 impl Default for Builder {
@@ -170,7 +170,7 @@ impl Builder {
 
     /// Set the hoards map.
     #[must_use]
-    pub fn set_hoards(mut self, hoards: BTreeMap<String, Hoard>) -> Self {
+    pub fn set_hoards(mut self, hoards: HashMap<String, Hoard>) -> Self {
         tracing::trace!(?hoards, "setting hoards");
         self.hoards = Some(hoards);
         self
@@ -265,7 +265,7 @@ impl Builder {
     /// Any error that occurs while evaluating the environments.
     fn evaluated_environments(
         &self,
-    ) -> Result<BTreeMap<String, bool>, <Environment as TryInto<bool>>::Error> {
+    ) -> Result<HashMap<String, bool>, <Environment as TryInto<bool>>::Error> {
         let _span = tracing::trace_span!("eval_env").entered();
         if let Some(envs) = &self.environments {
             for (key, env) in envs {
@@ -274,7 +274,7 @@ impl Builder {
         }
 
         self.environments.as_ref().map_or_else(
-            || Ok(BTreeMap::new()),
+            || Ok(HashMap::new()),
             |map| {
                 map.iter()
                     .map(|(key, env)| Ok((key.clone(), env.clone().try_into()?)))
@@ -306,7 +306,7 @@ impl Builder {
         tracing::debug!("processing hoards...");
         let hoards = self
             .hoards
-            .unwrap_or_else(BTreeMap::new)
+            .unwrap_or_else(HashMap::new)
             .into_iter()
             .map(|(name, hoard)| {
                 let _span = tracing::debug_span!("processing_hoard", %name).entered();

--- a/src/config/hoard.rs
+++ b/src/config/hoard.rs
@@ -3,7 +3,8 @@
 //! for more details.
 
 pub use super::builder::hoard::Config;
-use std::collections::BTreeMap;
+use crate::history::last_paths::HoardPaths;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 use thiserror::Error;
@@ -64,6 +65,8 @@ pub struct Pile {
 
 impl Pile {
     /// Helper function for copying files and directories.
+    ///
+    /// The returned [`PilePaths`] has items inserted as (src, dest).
     ///
     /// # Errors
     ///
@@ -281,6 +284,20 @@ impl Hoard {
         match self {
             Hoard::Single(single) => single.restore(prefix),
             Hoard::Multiple(multiple) => multiple.restore(prefix),
+        }
+    }
+
+    /// Returns a [`HoardPaths`] based on this `Hoard`.
+    #[must_use]
+    pub fn get_paths(&self) -> HoardPaths {
+        match self {
+            Hoard::Single(pile) => pile.path.clone().into(),
+            Hoard::Multiple(piles) => piles
+                .piles
+                .iter()
+                .filter_map(|(key, val)| val.path.clone().map(|path| (key.clone(), path)))
+                .collect::<HashMap<_, _>>()
+                .into(),
         }
     }
 }

--- a/src/config/hoard.rs
+++ b/src/config/hoard.rs
@@ -4,7 +4,7 @@
 
 pub use super::builder::hoard::Config;
 use crate::checkers::history::last_paths::HoardPaths;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 use thiserror::Error;
@@ -199,7 +199,7 @@ impl Pile {
 #[derive(Clone, Debug, PartialEq)]
 pub struct MultipleEntries {
     /// The named [`Pile`]s in the hoard.
-    pub piles: BTreeMap<String, Pile>,
+    pub piles: HashMap<String, Pile>,
 }
 
 impl MultipleEntries {

--- a/src/config/hoard.rs
+++ b/src/config/hoard.rs
@@ -3,7 +3,7 @@
 //! for more details.
 
 pub use super::builder::hoard::Config;
-use crate::history::last_paths::HoardPaths;
+use crate::checkers::history::last_paths::HoardPaths;
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::{fs, io};

--- a/src/config/hoard.rs
+++ b/src/config/hoard.rs
@@ -249,9 +249,9 @@ impl MultipleEntries {
 #[allow(variant_size_differences)]
 pub enum Hoard {
     /// A single anonymous [`Pile`].
-    Single(Pile),
+    Anonymous(Pile),
     /// Multiple named [`Pile`]s.
-    Multiple(MultipleEntries),
+    Named(MultipleEntries),
 }
 
 impl Hoard {
@@ -266,8 +266,8 @@ impl Hoard {
                 .entered();
 
         match self {
-            Hoard::Single(single) => single.backup(prefix),
-            Hoard::Multiple(multiple) => multiple.backup(prefix),
+            Hoard::Anonymous(single) => single.backup(prefix),
+            Hoard::Named(multiple) => multiple.backup(prefix),
         }
     }
 
@@ -282,8 +282,8 @@ impl Hoard {
                 .entered();
 
         match self {
-            Hoard::Single(single) => single.restore(prefix),
-            Hoard::Multiple(multiple) => multiple.restore(prefix),
+            Hoard::Anonymous(single) => single.restore(prefix),
+            Hoard::Named(multiple) => multiple.restore(prefix),
         }
     }
 
@@ -291,8 +291,8 @@ impl Hoard {
     #[must_use]
     pub fn get_paths(&self) -> HoardPaths {
         match self {
-            Hoard::Single(pile) => pile.path.clone().into(),
-            Hoard::Multiple(piles) => piles
+            Hoard::Anonymous(pile) => pile.path.clone().into(),
+            Hoard::Named(piles) => piles
                 .piles
                 .iter()
                 .filter_map(|(key, val)| val.path.clone().map(|path| (key.clone(), path)))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,9 +2,9 @@
 
 pub use self::builder::Builder;
 use self::hoard::Hoard;
-use crate::checkers::Checker;
 use crate::checkers::history::last_paths::{Error as LastPathsError, LastPaths};
 use crate::checkers::history::operation::{Error as HoardOperationError, HoardOperation};
+use crate::checkers::Checker;
 use crate::command::Command;
 use directories::ProjectDirs;
 use std::collections::HashMap;
@@ -122,14 +122,24 @@ impl Config {
         self.hoards_root.clone()
     }
 
-    fn get_hoards<'a>(&'a self, hoards: &'a [String]) -> Result<HashMap<&'a str, &'a Hoard>, Error> {
+    fn get_hoards<'a>(
+        &'a self,
+        hoards: &'a [String],
+    ) -> Result<HashMap<&'a str, &'a Hoard>, Error> {
         if hoards.is_empty() {
             tracing::debug!("no hoard names provided, acting on all of them.");
-            Ok(self.hoards.iter().map(|(key, val)| (key.as_str(), val)).collect())
+            Ok(self
+                .hoards
+                .iter()
+                .map(|(key, val)| (key.as_str(), val))
+                .collect())
         } else {
             tracing::debug!("using hoard names provided on cli");
             tracing::trace!(?hoards);
-            hoards.iter().map(|key| self.get_hoard(key).map(|hoard| (key.as_str(), hoard))).collect()
+            hoards
+                .iter()
+                .map(|key| self.get_hoard(key).map(|hoard| (key.as_str(), hoard)))
+                .collect()
         }
     }
 
@@ -218,7 +228,10 @@ impl Checkers {
             operations.insert((*name).to_string(), op);
         }
 
-        Ok(Self { last_paths, operations })
+        Ok(Self {
+            last_paths,
+            operations,
+        })
     }
 
     fn check(&mut self) -> Result<(), Error> {
@@ -233,7 +246,11 @@ impl Checkers {
     }
 
     fn commit_to_disk(self) -> Result<(), Error> {
-        let Self { last_paths, operations, .. } = self;
+        let Self {
+            last_paths,
+            operations,
+            ..
+        } = self;
         for (_, last_path) in last_paths {
             last_path.commit_to_disk()?;
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -151,9 +151,9 @@ impl Config {
     fn check_and_set_same_paths(
         &self,
         name: &str,
-        last_paths: &mut LastPaths,
     ) -> Result<(), Error> {
         let _span = tracing::info_span!("checking for inconsistencies against previous operation", hoard=%name).entered();
+        let mut last_paths = LastPaths::from_default_file()?;
         let hoard_paths = self.get_hoard(name)?.get_paths();
         // If forcing the operation, don't bother checking.
         if !self.force {
@@ -185,9 +185,8 @@ impl Config {
             }
             Command::Backup { hoards } => {
                 let hoards = self.get_hoards(hoards);
-                let mut last_paths = LastPaths::from_default_file()?;
                 for name in hoards {
-                    self.check_and_set_same_paths(name, &mut last_paths)?;
+                    self.check_and_set_same_paths(name)?;
                     let prefix = self.get_prefix(name);
                     let hoard = self.get_hoard(name)?;
 
@@ -201,9 +200,8 @@ impl Config {
             }
             Command::Restore { hoards } => {
                 let hoards = self.get_hoards(hoards);
-                let mut last_paths = LastPaths::from_default_file()?;
                 for name in hoards {
-                    self.check_and_set_same_paths(name, &mut last_paths)?;
+                    self.check_and_set_same_paths(name)?;
                     let prefix = self.get_prefix(name);
                     let hoard = self.get_hoard(name)?;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -152,7 +152,8 @@ impl Config {
         &self,
         name: &str,
     ) -> Result<(), Error> {
-        let _span = tracing::info_span!("checking for inconsistencies against previous operation", hoard=%name).entered();
+        let _span = tracing::info_span!("consistency_checks", hoard=%name).entered();
+        tracing::info!("checking for inconsistencies against previous operation");
         let mut last_paths = LastPaths::from_default_file()?;
         let hoard_paths = self.get_hoard(name)?.get_paths();
         // If forcing the operation, don't bother checking.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,12 +3,12 @@
 pub use self::builder::Builder;
 use self::hoard::Hoard;
 use crate::checkers::history::last_paths::{Error as LastPathsError, HoardPaths, LastPaths};
+use crate::checkers::history::operation::{Error as HoardOperationError, HoardOperation};
 use crate::command::Command;
 use directories::ProjectDirs;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use thiserror::Error;
-use crate::checkers::history::operation::{HoardOperation, Error as HoardOperationError};
 
 pub mod builder;
 pub mod hoard;
@@ -177,12 +177,15 @@ impl Config {
         Ok(())
     }
 
-
-    fn check_no_overwrite_remote_operations(&self, name: &str, is_backup: bool) -> Result<HoardOperation, Error> {
+    fn check_no_overwrite_remote_operations(
+        &self,
+        name: &str,
+        is_backup: bool,
+    ) -> Result<HoardOperation, Error> {
         let _span = tracing::info_span!("remote_operation_check", hoard=%name).entered();
         tracing::info!("ensuring no remote operations will be overwritten");
         let current_operation = HoardOperation::new(is_backup, self.get_hoard(name)?)?;
-        
+
         if !self.force && !current_operation.is_valid_pending(name)? {
             return Err(Error::RestoreRequired);
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,8 +2,8 @@
 
 pub use self::builder::Builder;
 use self::hoard::Hoard;
+use crate::checkers::history::last_paths::{Error as LastPathsError, HoardPaths, LastPaths};
 use crate::command::Command;
-use crate::history::last_paths::{Error as LastPathsError, HoardPaths, LastPaths};
 use directories::ProjectDirs;
 use std::collections::BTreeMap;
 use std::path::PathBuf;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -148,10 +148,7 @@ impl Config {
     /// This function should be run *before* doing any file operations on a hoard. It persists the
     /// paths used before the fallible file operations to prevent confusion (I would expect the
     /// "last paths used" file to have the paths that caused the error, not the run before).
-    fn check_and_set_same_paths(
-        &self,
-        name: &str,
-    ) -> Result<(), Error> {
+    fn check_and_set_same_paths(&self, name: &str) -> Result<(), Error> {
         let _span = tracing::info_span!("consistency_checks", hoard=%name).entered();
         tracing::info!("checking for inconsistencies against previous operation");
         let mut last_paths = LastPaths::from_default_file()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -181,10 +181,10 @@ impl Config {
         tracing::trace!(command = ?self.command, "running command");
         match &self.command {
             Command::Validate => {
-                tracing::info!("configuration is valid")
+                tracing::info!("configuration is valid");
             }
             Command::Backup { hoards } => {
-                let hoards = self.get_hoards(&hoards);
+                let hoards = self.get_hoards(hoards);
                 let mut last_paths = LastPaths::from_default_file()?;
                 for name in hoards {
                     self.check_and_set_same_paths(name, &mut last_paths)?;
@@ -200,7 +200,7 @@ impl Config {
                 }
             }
             Command::Restore { hoards } => {
-                let hoards = self.get_hoards(&hoards);
+                let hoards = self.get_hoards(hoards);
                 let mut last_paths = LastPaths::from_default_file()?;
                 for name in hoards {
                     self.check_and_set_same_paths(name, &mut last_paths)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,7 @@ use crate::checkers::history::last_paths::{Error as LastPathsError, HoardPaths, 
 use crate::checkers::history::operation::{Error as HoardOperationError, HoardOperation};
 use crate::command::Command;
 use directories::ProjectDirs;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -71,7 +71,7 @@ pub struct Config {
     /// Path to a configuration file.
     config_file: PathBuf,
     /// All of the configured hoards.
-    hoards: BTreeMap<String, Hoard>,
+    hoards: HashMap<String, Hoard>,
     /// Whether to force the operation to continue despite possible inconsistencies.
     force: bool,
 }

--- a/src/history/last_paths.rs
+++ b/src/history/last_paths.rs
@@ -1,0 +1,313 @@
+//! Types dedicated to recording which paths were used for each pile in the last
+//! operating using a given hoard.
+//!
+//! See the documentation for [`HoardPaths::enforce_old_and_new_piles_are_same`] for an
+//! explanation of why this is useful.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::{fs, io};
+use thiserror::Error;
+
+const FILE_NAME: &str = "last_paths.json";
+
+/// Errors that may occur while working with a [`LastPaths`] or related types.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// An error while parsing the JSON file.
+    #[error("could not parse {}: {0}", FILE_NAME)]
+    Serde(#[from] serde_json::Error),
+    /// An error while doing I/O.
+    #[error("an I/O error occurred: {0}")]
+    IO(#[from] io::Error),
+    /// Unexpected differences in hoard paths. Operation must be forced to continue.
+    #[error("paths used in current hoard operation do not match previous run")]
+    HoardPathsMismatch,
+}
+
+/// Collection of the last paths matched per hoard.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LastPaths(HashMap<String, HoardPaths>);
+
+fn get_last_paths_file_path() -> Result<PathBuf, io::Error> {
+    tracing::debug!("getting lastpaths file path");
+    let id = super::get_or_generate_uuid()?;
+    Ok(super::get_history_dir_for_id(id).join(FILE_NAME))
+}
+
+fn read_last_paths_file() -> Result<fs::File, io::Error> {
+    let path = get_last_paths_file_path()?;
+    tracing::debug!(?path, "opening lastpaths file at path");
+    fs::File::open(path)
+}
+
+fn save_last_paths_to_file(paths: &LastPaths) -> Result<(), Error> {
+    tracing::debug!("saving lastpaths to disk");
+    let path = get_last_paths_file_path()?;
+    tracing::trace!("converting lastpaths to JSON");
+    let content = serde_json::to_string(paths)?;
+    if let Some(parent) = path.parent() {
+        tracing::trace!("ensuring parent directories exist");
+        fs::create_dir_all(parent)?;
+    }
+    tracing::trace!("writing lastpaths file");
+    fs::write(path, content)?;
+    Ok(())
+}
+
+impl LastPaths {
+    /// Create a new, empty `LastPaths`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Get the entry for the given hoard, if exists.
+    #[must_use]
+    pub fn hoard(&self, hoard: &str) -> Option<&HoardPaths> {
+        self.0.get(hoard)
+    }
+
+    /// Set/overwrite the paths used for the given hoard.
+    pub fn set_hoard(&mut self, hoard: String, paths: HoardPaths) {
+        self.0.insert(hoard, paths);
+    }
+
+    /// Read the last paths from the default file.
+    ///
+    /// # Errors
+    ///
+    /// Any I/O or `serde` error that occurs while reading and parsing the file.
+    /// The exception is an I/O error with kind `NotFound`, which returns an empty
+    /// `LastPaths`.
+    pub fn from_default_file() -> Result<Self, Error> {
+        tracing::debug!("reading lastpaths from file");
+        let reader = match read_last_paths_file() {
+            Ok(file) => file,
+            Err(err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    tracing::debug!("lastpaths file not found, creating new instance");
+                    return Ok(Self::new());
+                }
+                tracing::error!(error=%err);
+                return Err(err.into());
+            }
+        };
+
+        serde_json::from_reader(reader).map_err(Into::into)
+    }
+
+    /// Save this `LastPaths` to the `last_paths` file.
+    ///
+    /// # Errors
+    ///
+    /// Any I/O or `serde` error that occurs while saving this `LastPaths`.
+    pub fn save_to_disk(&self) -> Result<(), Error> {
+        save_last_paths_to_file(self)
+    }
+}
+
+impl Default for LastPaths {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// An entry for the last time a hoard was processed.
+///
+/// Contains the timestamp of the last operation on this hoard and a mapping
+/// of every file in each of its piles to the corresponding path outside of the
+/// hoard.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HoardPaths {
+    timestamp: chrono::DateTime<chrono::Utc>,
+    piles: PilePaths,
+}
+
+/// Internal type for [`HoardPaths`] mapping to anonymous or named piles.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PilePaths {
+    /// A single, anonymous pile's path.
+    Anonymous(Option<PathBuf>),
+    /// One or more named piles and their paths.
+    Named(HashMap<String, PathBuf>),
+}
+
+impl From<PathBuf> for PilePaths {
+    fn from(other: PathBuf) -> Self {
+        Self::Anonymous(Some(other))
+    }
+}
+
+impl From<Option<PathBuf>> for PilePaths {
+    fn from(other: Option<PathBuf>) -> Self {
+        Self::Anonymous(other)
+    }
+}
+
+impl From<HashMap<String, PathBuf>> for PilePaths {
+    fn from(other: HashMap<String, PathBuf>) -> Self {
+        Self::Named(other)
+    }
+}
+
+impl<T> From<T> for HoardPaths
+where
+    T: Into<PilePaths>,
+{
+    fn from(val: T) -> Self {
+        Self {
+            timestamp: chrono::offset::Utc::now(),
+            piles: val.into(),
+        }
+    }
+}
+
+impl HoardPaths {
+    /// Get the timestamp of the last operation on this hoard.
+    #[must_use]
+    pub fn time(&self) -> &chrono::DateTime<chrono::Utc> {
+        &self.timestamp
+    }
+
+    /// Get the entries for a pile by name.
+    ///
+    /// Returns `None` if the named pile is not found or if the hoard contains an
+    /// anonymous pile.
+    #[must_use]
+    pub fn named_pile(&self, name: &str) -> Option<&PathBuf> {
+        if let PilePaths::Named(named) = &self.piles {
+            named.get(name)
+        } else {
+            None
+        }
+    }
+
+    /// Get the entries for the anonymous pile.
+    ///
+    /// Returns `None` if the hoard contains named piles.
+    #[must_use]
+    pub fn anonymous_pile(&self) -> Option<&PathBuf> {
+        if let PilePaths::Anonymous(path) = &self.piles {
+            path.as_ref()
+        } else {
+            None
+        }
+    }
+
+    /// Logs any inconsistencies and returns an error if any are found.
+    ///
+    /// This check basically returns an error if `old != new`, but does some extra checking to
+    /// provided better logged warnings depending on what the mismatch is.
+    ///
+    /// Any mismatch is considered an inconsistency because it may mean that one of the following
+    /// occurs because of an unexpected change in the system configuration:
+    ///
+    /// - Backing up an empty/non-existent directory unintentionally deletes the current backup.
+    /// - Restoring to an unexpected directory causes nothing to change in the intended one.
+    /// - Files don't get backed up or restored because the system configuration did not match a
+    ///   pile's environment string.
+    ///
+    /// # Example
+    ///
+    /// I sometimes run a normal Steam installation on a Linux machine, sometimes the flatpak version.
+    /// If the flatpak install takes priority over the normal install, the following set of events
+    /// might occur:
+    ///
+    /// - Install flatpak Steam to try it out.
+    /// - Realize I should back up my normal Steam saves so I can restore them to the flatpak locations.
+    ///   - Alternatively, I told `hoard` to do this already and assumed it finished, but a different
+    ///     hoard took longer than expected to back up.
+    ///   - Either way, a backup happens after installing flatpak Steam.
+    /// - Existing backup is erased so the new one is a clean backup.
+    /// - The associated directories for flatpak are empty or don't exist, so nothing gets backed up.
+    /// - My backups are all deleted.
+    ///
+    /// There are ways to recover from this, for example by uninstalling flatpak Steam and doing
+    /// another backup, but the situation gets more complex when considering multiple devices
+    /// each synchronizing files to each other. It's much easier to make this check and, if the
+    /// changes are intended, have the user indicate as much.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::HoardPathsMismatch`] if there is a difference between `old` and `new`.
+    pub fn enforce_old_and_new_piles_are_same(old: &Self, new: &Self) -> Result<(), Error> {
+        tracing::debug!("comparing old and new piles' paths");
+        tracing::trace!(?old, ?new);
+        match (&old.piles, &new.piles) {
+            (PilePaths::Anonymous(old), PilePaths::Anonymous(new)) => {
+                tracing::trace!("both piles are anonymous");
+                if old.is_some() && new.is_none() {
+                    tracing::warn!(old_path=?old, "anonymous pile no longer has a path");
+                    return Err(Error::HoardPathsMismatch);
+                } else if old.is_none() && new.is_some() {
+                    // TODO: This case may be necessary when restoring: consider.
+                    tracing::warn!(new_path=?new, "anonymous pile matches a path but previously did not");
+                    return Err(Error::HoardPathsMismatch);
+                } else if let (Some(old), Some(new)) = (old, new) {
+                    // If both are None, they are the same. So check only for both as Some(_).
+                    // Then check if the paths match.
+                    if old != new {
+                        tracing::warn!(?old, ?new, "anonymous pile path changed");
+                        return Err(Error::HoardPathsMismatch);
+                    }
+                }
+
+                return Err(Error::HoardPathsMismatch);
+            }
+            (PilePaths::Anonymous(_), PilePaths::Named(_)) => {
+                tracing::warn!("hoard previously with anonymous pile now has named pile(s)");
+                return Err(Error::HoardPathsMismatch);
+            }
+            (PilePaths::Named(_), PilePaths::Anonymous(_)) => {
+                tracing::warn!("hoard previously with named pile(s) now has an anonymous pile");
+                return Err(Error::HoardPathsMismatch);
+            }
+            (PilePaths::Named(old), PilePaths::Named(new)) => {
+                tracing::trace!("both piles are named");
+                let old_set: HashSet<&str> = old.keys().map(String::as_str).collect();
+                let new_set: HashSet<&str> = new.keys().map(String::as_str).collect();
+
+                let only_in_old: Vec<&str> = old_set.difference(&new_set).copied().collect();
+                let only_in_new: Vec<&str> = new_set.difference(&old_set).copied().collect();
+
+                // Warn about both before returning.
+                if !only_in_old.is_empty() {
+                    tracing::warn!(piles=?only_in_old, "named piles previously with path no longer have a path");
+                }
+                if !only_in_new.is_empty() {
+                    tracing::warn!(piles=?only_in_new, "named piles previously without path now have a path");
+                }
+
+                // Now return if either difference occurred.
+                if !only_in_old.is_empty() || !only_in_new.is_empty() {
+                    return Err(Error::HoardPathsMismatch);
+                }
+
+                // If all of the same piles exist, check if all the paths are the same.
+                // Can expect because the above checks for any mismatched keys.
+                let mut mismatch = false;
+                for (key, old_path) in old {
+                    let new_path = new.get(key).expect("key should exist in map");
+                    if old_path != new_path {
+                        mismatch = true;
+                        tracing::warn!(
+                            ?old_path,
+                            ?new_path,
+                            "pile \"{}\" has a different path",
+                            key
+                        );
+                    }
+                }
+
+                if mismatch {
+                    return Err(Error::HoardPathsMismatch);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,0 +1,62 @@
+use crate::config::get_dirs;
+use std::path::PathBuf;
+use std::{fs, io};
+use uuid::Uuid;
+
+const UUID_FILE_NAME: &str = "uuid";
+
+fn get_uuid_file() -> PathBuf {
+    get_dirs().config_dir().join(UUID_FILE_NAME)
+}
+
+/// Get this machine's unique UUID, creating if necessary.
+///
+/// The UUID can be found in a file called "uuid" in the `hoard`
+/// configuration directory. If the file cannot be found or its contents are invalid,
+/// a new file is created.
+///
+/// # Errors
+///
+/// Any I/O unexpected errors that may occur while reading and/or
+/// writing the UUID file.
+pub fn get_or_generate_uuid() -> Result<Uuid, io::Error> {
+    let uuid_file = get_uuid_file();
+    let _span = tracing::debug_span!("get_uuid", file = ?uuid_file);
+
+    tracing::debug!("attempting to read uuid from file");
+    let id: Option<Uuid> = match fs::read_to_string(&uuid_file) {
+        Ok(id) => match id.parse() {
+            Ok(id) => {
+                tracing::trace!(uuid = %id, "successfully read uuid from file");
+                Some(id)
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, bad_id = %id, "failed to parse uuid in file");
+                None
+            }
+        },
+        Err(err) => {
+            if err.kind() == io::ErrorKind::NotFound {
+                tracing::trace!("no uuid file found: creating one");
+                None
+            } else {
+                tracing::error!(error = %err, "error while reading uuid file");
+                return Err(err);
+            }
+        }
+    };
+
+    // Return existing id or generate, save to file, and return.
+    id.map_or_else(
+        || {
+            let new_id = Uuid::new_v4();
+            tracing::debug!(new_uuid = %new_id, "generated new uuid");
+            if let Err(err) = fs::write(&uuid_file, new_id.to_string()) {
+                tracing::error!(error = %err, "error while saving uuid to file");
+                return Err(err);
+            }
+            Ok(new_id)
+        },
+        Ok,
+    )
+}

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,12 +1,29 @@
+//! Keep records of previous operations (including on other system) to prevent inconsistencies
+//! and accidental overwrites or deletions.
+//!
+//! This module currently focuses on the [`last_paths`] submodule, which gives a warning and
+//! aborts an operation if the paths being used differ from the previous operation.
+
 use crate::config::get_dirs;
 use std::path::PathBuf;
 use std::{fs, io};
 use uuid::Uuid;
 
+pub mod last_paths;
+
 const UUID_FILE_NAME: &str = "uuid";
+const HISTORY_DIR_NAME: &str = "history";
 
 fn get_uuid_file() -> PathBuf {
     get_dirs().config_dir().join(UUID_FILE_NAME)
+}
+
+fn get_history_root_dir() -> PathBuf {
+    get_dirs().data_dir().join(HISTORY_DIR_NAME)
+}
+
+fn get_history_dir_for_id(id: Uuid) -> PathBuf {
+    get_history_root_dir().join(id.to_string())
 }
 
 /// Get this machine's unique UUID, creating if necessary.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,11 @@
 )]
 pub use config::Config;
 
+pub mod checkers;
 pub mod combinator;
 pub mod command;
 pub mod config;
 pub mod env_vars;
-pub mod history;
 
 /// The default file name of the configuration file.
 pub const CONFIG_FILE_NAME: &str = "config.toml";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub mod combinator;
 pub mod command;
 pub mod config;
 pub mod env_vars;
+pub mod history;
 
 /// The default file name of the configuration file.
 pub const CONFIG_FILE_NAME: &str = "config.toml";


### PR DESCRIPTION
Resolves #26 and #28.

Implements two checks:

# Check 1: Last Paths

This check validates that the paths being used in the current operation are the same as the most recent operation on that hoard. If the paths are different, this may constitute an unintentional environment change. Users can double-check that the paths being used are the intended ones, and then use the `--force` flag to make the operation go through.

# Check 2: Remote Operations

This check uses (hopefully synchronized) records from other systems to determine if the most recent update of a file happened locally or on a remote system. If it happened on a remote system, any *backup* operation is cancelled to prevent accidentally overwriting remote changes. Again, this check can be disabled using the `--force` flag.