### PR TITLE
#27: ignore paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +194,7 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "directories",
+ "glob",
  "hostname",
  "maplit",
  "md-5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/Shadow53/hoard"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 directories = "3.0.1"
+glob = "0.3"
 hostname = "0.3"
 md-5 = "0.9"
 once_cell = "1.7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN cargo build
 
 FROM python:alpine
 
-ENV CI=true GITHUB_ACTIONS=true HOARD_LOG=trace
+ENV CI=true GITHUB_ACTIONS=true HOARD_LOG=debug
 COPY ci-tests ci-tests
 COPY --from=build target/debug/hoard target/debug/hoard
 
 RUN apk add tree
 RUN python3 ci-tests/test.py last_paths
 RUN python3 ci-tests/test.py operation
+RUN python3 ci-tests/test.py ignore

--- a/ci-tests/config.toml
+++ b/ci-tests/config.toml
@@ -15,6 +15,9 @@ exclusivity = [
     os = ["linux", "macos"]
     env = [{ var = "HOME" }]
 
+[config]
+    ignore = ["*global*"]
+
 [hoards]
 [hoards.anon_dir]
     "unix|first"  = "${HOME}/first_anon_dir"
@@ -27,13 +30,21 @@ exclusivity = [
     "windows|first"  = "C:/${HOMEPATH}/first_anon_file"
     "windows|second" = "C:/${HOMEPATH}/second_anon_file"
 [hoards.named]
+    [hoards.named.config]
+        ignore = ["*hoard*"]
     [hoards.named.file]
         "unix|first"  = "${HOME}/first_named_file"
         "unix|second" = "${HOME}/second_named_file"
         "windows|first"  = "C:/${HOMEPATH}/first_named_file"
         "windows|second" = "C:/${HOMEPATH}/second_named_file"
-    [hoards.named.dir]
-        "unix|first"  = "${HOME}/first_named_dir"
-        "unix|second" = "${HOME}/second_named_dir"
-        "windows|first"  = "C:/${HOMEPATH}/first_named_dir"
-        "windows|second" = "C:/${HOMEPATH}/second_named_dir"
+    [hoards.named.dir1]
+        config = { ignore = ["*pile*", ".hidden"] }
+        "unix|first"  = "${HOME}/first_named_dir1"
+        "unix|second" = "${HOME}/second_named_dir1"
+        "windows|first"  = "C:/${HOMEPATH}/first_named_dir1"
+        "windows|second" = "C:/${HOMEPATH}/second_named_dir1"
+    [hoards.named.dir2]
+        "unix|first"  = "${HOME}/first_named_dir2"
+        "unix|second" = "${HOME}/second_named_dir2"
+        "windows|first"  = "C:/${HOMEPATH}/first_named_dir2"
+        "windows|second" = "C:/${HOMEPATH}/second_named_dir2"

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -40,6 +40,13 @@ def data_dir_path():
         raise OSError("could not determine system for CI tests")
 
 
+def generate_file(path, size=1024):
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "wb") as file:
+        content = secrets.token_bytes(size)
+        file.write(content)
+
+
 def setup():
     home = Path.home()
 
@@ -54,16 +61,11 @@ def setup():
         pass
 
     for env in ["first", "second"]:
-        for item in ["anon_dir", "named_dir"]:
+        for item in ["anon_dir", "named_dir1", "named_dir2"]:
             for num in [1, 2, 3]:
-                os.makedirs(home.joinpath(f"{env}_{item}"), exist_ok=True)
-                with open(home.joinpath(f"{env}_{item}", str(num)), "wb") as file:
-                    content = secrets.token_bytes(num * 1024)
-                    file.write(content)
+                generate_file(home.joinpath(f"{env}_{item}", str(num)), 1024 * num)
         for item in ["anon_file", "named_file"]:
-            with open(home.joinpath(f"{env}_{item}"), "wb") as file:
-                content = secrets.token_bytes(2048)
-                file.write(content)
+            generate_file(home.joinpath(f"{env}_{item}"))
     os.makedirs(config_file_path().parent)
     shutil.copy2(Path.cwd().joinpath("ci-tests", "config.toml"), config_file_path())
 
@@ -99,8 +101,13 @@ def assert_first_tree():
         data_dir.joinpath("hoards", "anon_file")
     )
     assert_same_tree(
-        home.joinpath("first_named_dir"),
-        data_dir.joinpath("hoards", "named", "dir"),
+        home.joinpath("first_named_dir1"),
+        data_dir.joinpath("hoards", "named", "dir1"),
+        direntries=["1", "2", "3"]
+    )
+    assert_same_tree(
+        home.joinpath("first_named_dir2"),
+        data_dir.joinpath("hoards", "named", "dir2"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
@@ -122,8 +129,13 @@ def assert_second_tree():
         data_dir.joinpath("hoards", "anon_file")
     )
     assert_same_tree(
-        home.joinpath("second_named_dir"),
-        data_dir.joinpath("hoards", "named", "dir"),
+        home.joinpath("second_named_dir1"),
+        data_dir.joinpath("hoards", "named", "dir1"),
+        direntries=["1", "2", "3"]
+    )
+    assert_same_tree(
+        home.joinpath("second_named_dir2"),
+        data_dir.joinpath("hoards", "named", "dir2"),
         direntries=["1", "2", "3"]
     )
     assert_same_tree(
@@ -230,6 +242,56 @@ def test_operation_checker():
     run_hoard("backup", env=env, force=True)
 
 
+def test_ignore_filter():
+    # Do setup
+    setup()
+    # We are not changing env on this test
+    env = {"USE_ENV": "1"}
+    # All three of global, hoard, and pile-ignore files should be ignored.
+    global_file = "global_ignore"
+    hoard_file = "ignore_for_hoard"
+    pile_file = "spilem"
+
+    # Create files to ignore
+    anon_dir_root = Path.home().joinpath("first_anon_dir")
+    named_dir1_root = Path.home().joinpath("first_named_dir1")
+    named_dir2_root = Path.home().joinpath("first_named_dir2")
+
+    for root in [anon_dir_root, named_dir1_root, named_dir2_root]:
+        for file in [global_file, hoard_file, pile_file]:
+            generate_file(root.joinpath(file))
+
+    # Run hoard
+    run_hoard("backup", env=env)
+
+    # Delete unexpected files for assert_same_tree
+    # Named dir1 pile should only ignore pile (overwrites global and hoard)
+    os.remove(named_dir1_root.joinpath(pile_file))
+    # Named dir2 pile should only ignore hoard (overwrites global)
+    os.remove(named_dir2_root.joinpath(hoard_file))
+    # Anon dir should only ignore global
+    os.remove(anon_dir_root.joinpath(global_file))
+
+    # Assert trees
+    home = Path.home()
+    data_dir = data_dir_path()
+    assert_same_tree(
+        home.joinpath("first_anon_dir"),
+        data_dir.joinpath("hoards", "anon_dir"),
+        direntries=["1", "2", "3", pile_file, hoard_file]
+    )
+    assert_same_tree(
+        home.joinpath("first_named_dir1"),
+        data_dir.joinpath("hoards", "named", "dir1"),
+        direntries=["1", "2", "3", hoard_file, global_file]
+    )
+    assert_same_tree(
+        home.joinpath("first_named_dir2"),
+        data_dir.joinpath("hoards", "named", "dir2"),
+        direntries=["1", "2", "3", pile_file, global_file]
+    )
+
+
 if __name__ == "__main__":
     if len(sys.argv) == 1:
         raise RuntimeError("One argument - the test - is required")
@@ -240,6 +302,9 @@ if __name__ == "__main__":
         elif sys.argv[1] == "operation":
             print("Running operation test")
             test_operation_checker()
+        elif sys.argv[1] == "ignore":
+            print("Running ignore filter test")
+            test_ignore_filter()
         else:
             raise RuntimeError(f"Invalid argument {sys.argv[1]}")
     except Exception:

--- a/ci-tests/test.py
+++ b/ci-tests/test.py
@@ -311,5 +311,5 @@ if __name__ == "__main__":
         print("\nHoards:")
         subprocess.run(["tree", str(data_dir_path())])
         print("\nHome:")
-        subprocess.run(["tree", str(Path.home())])
+        subprocess.run(["tree", "-L", "4"])
         raise

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -382,14 +382,14 @@ impl EnvTrie {
     ///
     /// Any [`enum@Error`] relating to parsing or validating environment condition strings.
     pub fn new(
-        environments: &HashMap<String, String>,
+        envs: &HashMap<String, String>,
         exclusive_list: &[Vec<String>],
     ) -> Result<Self, Error> {
         let _span =
-            tracing::trace_span!("create_envtrie", ?environments, ?exclusive_list).entered();
+            tracing::trace_span!("create_envtrie", ?envs, ?exclusive_list).entered();
         tracing::trace!("creating a new envtrie");
 
-        validate_environments(environments)?;
+        validate_environments(envs)?;
         let weighted_map = get_weighted_map(exclusive_list)?;
         let exclusivity_map = get_exclusivity_map(exclusive_list);
 
@@ -399,7 +399,7 @@ impl EnvTrie {
             ?weighted_map,
             "building trees for each environment string"
         );
-        let trees: Vec<_> = environments
+        let trees: Vec<_> = envs
             .iter()
             .map(|(env_str, path)| {
                 let _span =

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -385,8 +385,7 @@ impl EnvTrie {
         envs: &HashMap<String, String>,
         exclusive_list: &[Vec<String>],
     ) -> Result<Self, Error> {
-        let _span =
-            tracing::trace_span!("create_envtrie", ?envs, ?exclusive_list).entered();
+        let _span = tracing::trace_span!("create_envtrie", ?envs, ?exclusive_list).entered();
         tracing::trace!("creating a new envtrie");
 
         validate_environments(envs)?;

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -241,9 +241,9 @@ mod tests {
         fn single_entry_with_config() {
             let hoard = Hoard::Single(Pile {
                 config: Some(Config {
-                    encryption: Encryption::Asymmetric(AsymmetricEncryption {
+                    encryption: Some(Encryption::Asymmetric(AsymmetricEncryption {
                         public_key: "public key".to_string(),
-                    }),
+                    })),
                     ignore: Vec::new(),
                 }),
                 items: hashmap! {
@@ -262,6 +262,9 @@ mod tests {
                     Token::Str("asymmetric"),
                     Token::Str("encrypt_pub_key"),
                     Token::Str("public key"),
+                    Token::Str("ignore"),
+                    Token::Seq { len: Some(0) },
+                    Token::SeqEnd,
                     Token::MapEnd,
                     Token::Str("bar_env|foo_env"),
                     Token::Str("/some/path"),
@@ -306,9 +309,9 @@ mod tests {
         fn multiple_entry_with_config() {
             let hoard = Hoard::Multiple(MultipleEntries {
                 config: Some(Config {
-                    encryption: Encryption::Symmetric(SymmetricEncryption::Password(
+                    encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
                         "correcthorsebatterystaple".into(),
-                    )),
+                    ))),
                     ignore: Vec::new(),
                 }),
                 items: hashmap! {
@@ -332,6 +335,9 @@ mod tests {
                     Token::Str("symmetric"),
                     Token::Str("encrypt_pass"),
                     Token::Str("correcthorsebatterystaple"),
+                    Token::Str("ignore"),
+                    Token::Seq { len: Some(0) },
+                    Token::SeqEnd,
                     Token::MapEnd,
                     Token::Str("item1"),
                     Token::Map { len: None },

--- a/src/config/builder/mod.rs
+++ b/src/config/builder/mod.rs
@@ -16,8 +16,8 @@ use crate::command::Command;
 use crate::CONFIG_FILE_NAME;
 use crate::HOARDS_DIR_SLUG;
 
+use self::hoard::Config as PileConfig;
 use super::Config;
-use hoard::Config as PileConfig;
 
 pub mod environment;
 pub mod envtrie;

--- a/src/config/builder/mod.rs
+++ b/src/config/builder/mod.rs
@@ -17,6 +17,7 @@ use crate::CONFIG_FILE_NAME;
 use crate::HOARDS_DIR_SLUG;
 
 use super::Config;
+use hoard::Config as PileConfig;
 
 pub mod environment;
 pub mod envtrie;
@@ -63,6 +64,9 @@ pub struct Builder {
     force: bool,
     #[structopt(skip)]
     hoards: Option<HashMap<String, Hoard>>,
+    #[structopt(skip)]
+    #[serde(rename = "config")]
+    global_config: Option<PileConfig>,
 }
 
 impl Default for Builder {
@@ -99,6 +103,7 @@ impl Builder {
             environments: None,
             exclusivity: None,
             force: false,
+            global_config: None,
         }
     }
 
@@ -288,7 +293,7 @@ impl Builder {
     /// # Errors
     ///
     /// Any [`enum@Error`] that occurs while evaluating environment or hoard definitions.
-    pub fn build(self) -> Result<Config, Error> {
+    pub fn build(mut self) -> Result<Config, Error> {
         tracing::debug!("building configuration from builder");
         let environments = self.evaluated_environments()?;
         tracing::debug!(?environments);
@@ -302,6 +307,16 @@ impl Builder {
         tracing::debug!(?command);
         let force = self.force;
         tracing::debug!(?force);
+
+        if let (Some(global), Some(hoards)) = (self.global_config, &mut self.hoards) {
+            tracing::debug!("copying global config to hoards without one");
+            for (_, hoard) in hoards.iter_mut() {
+                match hoard {
+                    Hoard::Single(pile) => pile.set_config_if_none(Some(&global)),
+                    Hoard::Multiple(multi) => multi.set_config_if_none(Some(&global)),
+                }
+            }
+        }
 
         tracing::debug!("processing hoards...");
         let hoards = self
@@ -341,6 +356,7 @@ mod tests {
                 exclusivity: None,
                 hoards: None,
                 force: false,
+                global_config: None,
             }
         }
 
@@ -355,6 +371,7 @@ mod tests {
                 exclusivity: None,
                 hoards: None,
                 force: false,
+                global_config: None,
             }
         }
 
@@ -373,6 +390,7 @@ mod tests {
                 hoards: None,
                 exclusivity: None,
                 force: false,
+                global_config: None,
             };
 
             assert_eq!(

--- a/src/config/hoard.rs
+++ b/src/config/hoard.rs
@@ -4,7 +4,7 @@
 
 pub use super::builder::hoard::Config;
 use crate::checkers::history::last_paths::HoardPaths;
-use crate::filters::{Filter, Filters, Error as FilterError};
+use crate::filters::{Error as FilterError, Filter, Filters};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
@@ -86,7 +86,7 @@ impl Pile {
         if !filters.as_ref().map_or(true, |filters| filters.keep(src)) {
             // File should be ignored (not kept), so do nothing.
             tracing::trace!(path=%src.display(), "ignoring path based on filters");
-            return Ok(())
+            return Ok(());
         }
 
         // Fail if src and dest exist but are not both file or directory.

--- a/src/filters/ignore.rs
+++ b/src/filters/ignore.rs
@@ -1,3 +1,4 @@
+use crate::config::builder::hoard::Config;
 /// Provides a [`Filter`] based on glob ignore patterns.
 ///
 /// To use this filter, add an list of glob patterns to `ignore` under `config`. For example:
@@ -8,9 +9,7 @@
 /// ```
 ///
 /// This can be put under global, hoard, or pile scope.
-
 use glob::{Pattern, PatternError};
-use crate::config::builder::hoard::Config;
 
 use super::Filter;
 use thiserror::Error;
@@ -23,26 +22,25 @@ pub enum Error {
         pattern: String,
         #[source]
         error: PatternError,
-    }
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct IgnoreFilter {
-    globs: Vec<Pattern>
+    globs: Vec<Pattern>,
 }
 
 impl Filter for IgnoreFilter {
     type Error = Error;
 
     fn new(pile_config: &Config) -> Result<Self, Self::Error> {
-        pile_config.ignore
+        pile_config
+            .ignore
             .iter()
             .map(|pattern| {
-                Pattern::new(pattern).map_err(|error| {
-                    Error::InvalidGlob {
-                        pattern: pattern.clone(),
-                        error,
-                    }
+                Pattern::new(pattern).map_err(|error| Error::InvalidGlob {
+                    pattern: pattern.clone(),
+                    error,
                 })
             })
             .collect::<Result<_, _>>()

--- a/src/filters/ignore.rs
+++ b/src/filters/ignore.rs
@@ -1,0 +1,55 @@
+/// Provides a [`Filter`] based on glob ignore patterns.
+///
+/// To use this filter, add an list of glob patterns to `ignore` under `config`. For example:
+///
+/// ```ignore
+/// [config]
+///     ignore = ["some*glob"]
+/// ```
+///
+/// This can be put under global, hoard, or pile scope.
+
+use glob::{Pattern, PatternError};
+use crate::config::builder::hoard::Config;
+
+use super::Filter;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// An invalid glob was provided in the configuration file
+    #[error("invalid glob pattern \"{pattern}\": {error}")]
+    InvalidGlob {
+        pattern: String,
+        #[source]
+        error: PatternError,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct IgnoreFilter {
+    globs: Vec<Pattern>
+}
+
+impl Filter for IgnoreFilter {
+    type Error = Error;
+
+    fn new(pile_config: &Config) -> Result<Self, Self::Error> {
+        pile_config.ignore
+            .iter()
+            .map(|pattern| {
+                Pattern::new(pattern).map_err(|error| {
+                    Error::InvalidGlob {
+                        pattern: pattern.clone(),
+                        error,
+                    }
+                })
+            })
+            .collect::<Result<_, _>>()
+            .map(|globs| IgnoreFilter { globs })
+    }
+
+    fn keep(&self, path: &std::path::Path) -> bool {
+        self.globs.iter().all(|glob| !glob.matches_path(path))
+    }
+}

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,7 +1,7 @@
 //! Provides filters for determining whether a path should be backed up or not.
 
-use std::path::Path;
 use crate::config::builder::hoard::Config;
+use std::path::Path;
 use thiserror::Error;
 
 pub(crate) mod ignore;
@@ -39,7 +39,7 @@ impl Filter for Filters {
 
     fn new(pile_config: &Config) -> Result<Self, Self::Error> {
         let ignore = ignore::IgnoreFilter::new(pile_config)?;
-        Ok(Self{ ignore })
+        Ok(Self { ignore })
     }
 
     fn keep(&self, path: &Path) -> bool {

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,0 +1,48 @@
+//! Provides filters for determining whether a path should be backed up or not.
+
+use std::path::Path;
+use crate::config::builder::hoard::Config;
+use thiserror::Error;
+
+pub(crate) mod ignore;
+
+/// The [`Filter`] trait provides a common interface for all filters.
+pub trait Filter: Sized {
+    /// Any errors that may occur while creating a new filter.
+    type Error: std::error::Error;
+    /// Creates a new instance of something that implements [`Filter`].
+    ///
+    /// # Errors
+    ///
+    /// Any errors that may occur while creating the new filter.
+    fn new(pile_config: &Config) -> Result<Self, Self::Error>;
+    /// Whether or not the file should be kept (backed up).
+    fn keep(&self, path: &Path) -> bool;
+}
+
+/// Any errors that may occur while filtering.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// An error occurred in the Ignore filter.
+    #[error("error occurred in the ignore filter: {0}")]
+    Ignore(#[from] ignore::Error),
+}
+
+/// A wrapper for all implmented filters.
+#[derive(Debug, Clone)]
+pub struct Filters {
+    ignore: ignore::IgnoreFilter,
+}
+
+impl Filter for Filters {
+    type Error = Error;
+
+    fn new(pile_config: &Config) -> Result<Self, Self::Error> {
+        let ignore = ignore::IgnoreFilter::new(pile_config)?;
+        Ok(Self{ ignore })
+    }
+
+    fn keep(&self, path: &Path) -> bool {
+        self.ignore.keep(path)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub mod combinator;
 pub mod command;
 pub mod config;
 pub mod env_vars;
+pub mod filters;
 
 /// The default file name of the configuration file.
 pub const CONFIG_FILE_NAME: &str = "config.toml";


### PR DESCRIPTION
This adds a configuration item to ignore paths based on globs.

Configurations can be overridden on an all-or-nothing basis.