### PR TITLE
feat: add cleanup command with tests (#37)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -164,6 +164,9 @@ jobs:
       - name: Test Ignore Filter
         run: python ci-tests/tests ignore
 
+      - name: Test Ignore Filter
+        run: python ci-tests/tests cleanup
+
   release:
     if: github.event_name == 'release'
     runs-on: ${{ matrix.os }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y tree python3
 COPY --from=build target/debug/hoard target/debug/hoard
 COPY ci-tests ci-tests
 
+RUN python3 ci-tests/tests cleanup
 RUN python3 ci-tests/tests last_paths
 RUN python3 ci-tests/tests operation
 RUN python3 ci-tests/tests ignore

--- a/book/src/cli/flags-subcommands.md
+++ b/book/src/cli/flags-subcommands.md
@@ -16,3 +16,6 @@ Flags can be used with any subcommand and must be specified *before* any subcomm
 - Validate: `hoard [flags...] validate`
   - Attempt to parse the default configuration file (or the one provided via `--config-file`)
     Exits with code `0` if the config is valid.
+- Cleanup: `hoard [flags...] cleanup`
+  - Deletes all extra [operation log files](../file-locations.md#history-files)
+    that are unnecessary for the [check](./checks.md#remote-operations).

--- a/ci-tests/tests/__main__.py
+++ b/ci-tests/tests/__main__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from testers.ignore_filter import IgnoreFilterTester
 from testers.last_paths import LastPathsTester
 from testers.operations import OperationCheckerTester
+from testers.cleanup import LogCleanupTester
 from testers.hoard_tester import HoardFile, Environment
 
 for var in ["CI", "GITHUB_ACTIONS"]:
@@ -51,6 +52,9 @@ if __name__ == "__main__":
         elif sys.argv[1] == "ignore":
             print("Running ignore filter test")
             IgnoreFilterTester().run_test()
+        elif sys.argv[1] == "cleanup":
+            print("Running cleanup test")
+            LogCleanupTester().run_test()
         else:
             raise RuntimeError(f"Invalid argument {sys.argv[1]}")
     except Exception:

--- a/ci-tests/tests/testers/cleanup.py
+++ b/ci-tests/tests/testers/cleanup.py
@@ -1,0 +1,126 @@
+from .hoard_tester import HoardTester, Hoard, HoardFile, Environment
+from uuid import uuid4
+import os
+import secrets
+
+
+class LogCleanupTester(HoardTester):
+    def __init__(self):
+        self.reset()
+        self.env = {"USE_ENV": "1"}
+        self.system1 = str(uuid4())
+        self.system2 = str(uuid4())
+        # The number of `hoard` runs may seem excessive, but this is to
+        # simulate enough runs that one might want to clean up log files.
+        self.strategy = [
+            # All AnonDir operations
+            (self.system1, "backup", Hoard.AnonDir),
+            (self.system2, "restore", Hoard.AnonDir),
+            (self.system1, "backup", Hoard.AnonDir),
+            (self.system2, "restore", Hoard.AnonDir),
+            (self.system2, "backup", Hoard.AnonDir),
+            (self.system1, "restore", Hoard.AnonDir),
+            (self.system1, "backup", Hoard.AnonDir),
+            (self.system2, "restore", Hoard.AnonDir),
+            (self.system2, "backup", Hoard.AnonDir),
+            (self.system1, "restore", Hoard.AnonDir),
+            (self.system2, "restore", Hoard.AnonDir),
+            # All AnonFile operations
+            (self.system1, "backup", Hoard.AnonFile),
+            (self.system1, "backup", Hoard.AnonFile),
+            (self.system1, "restore", Hoard.AnonFile),
+            (self.system2, "restore", Hoard.AnonFile),
+            (self.system1, "backup", Hoard.AnonFile),
+            (self.system1, "restore", Hoard.AnonFile),
+            (self.system1, "backup", Hoard.AnonFile),
+            (self.system2, "restore", Hoard.AnonFile),
+            # All Named operations
+            (self.system2, "backup", Hoard.Named),
+            (self.system1, "restore", Hoard.Named),
+            (self.system2, "backup", Hoard.Named),
+            (self.system1, "restore", Hoard.Named),
+            (self.system1, "backup", Hoard.Named),
+            (self.system1, "restore", Hoard.Named),
+            (self.system2, "restore", Hoard.Named),
+            (self.system2, "backup", Hoard.Named),
+            (self.system1, "restore", Hoard.Named),
+            (self.system2, "backup", Hoard.Named),
+        ]
+        self.retained = {
+            self.system1: {
+                Hoard.AnonFile: [5],
+                Hoard.AnonDir: [3, 4],
+                Hoard.Named: [2, 4],
+            },
+            self.system2: {
+                Hoard.AnonFile: [1],
+                Hoard.AnonDir: [4, 5],
+                Hoard.Named: [4],
+            }
+        }
+
+        # In the end, these should be the final results:
+        # bkup = backups
+        # rstr = restore
+        # ALL CAPS indicates the most recent operation type
+        #
+        # +-------------------------------------------+
+        # |         | anon_dir | anon_file |  named   |
+        # +---------+----------+-----------+----------+
+        # | system1 | bkup x 3 | BKUP x 4  | bkup x 1 |
+        # |         | RSTR x 2 | rstr x 2  | RSTR x 4 |
+        # +---------+----------+-----------+----------+
+        # | system2 | bkup x 2 | bkup x 0  | BKUP x 4 |
+        # |         | RSTR x 4 | RSTR x 2  | rstr x 1 |
+        # +---------+----------+-----------+----------+
+
+    @classmethod
+    def _set_uuid_file(cls, system_id):
+        with open(cls.get_uuid_path(), 'w') as file:
+            file.write(system_id)
+
+    @classmethod
+    def _regenerate_file_in_hoard(cls, hoard):
+        content = secrets.token_bytes(1024)
+        if hoard is Hoard.AnonFile:
+            cls.write_hoard_file(Environment.First, HoardFile.AnonFile, content)
+        elif hoard is Hoard.AnonDir:
+            cls.write_hoard_file(Environment.First, HoardFile.AnonDir1, content)
+        elif hoard is Hoard.Named:
+            cls.write_hoard_file(Environment.First, HoardFile.NamedDir11, content)
+
+    def _run_operation(self, system_id, cmd, hoard):
+        self._regenerate_file_in_hoard(hoard)
+        self._set_uuid_file(system_id)
+        self.targets = [hoard.value]
+        self.run_hoard(cmd)
+
+    def run_test(self):
+        # Run all of the commands
+        for system_id, command, hoard in self.strategy:
+            self._run_operation(system_id, command, hoard)
+
+        expected = {}
+
+        for system_id, retained in self.retained.items():
+            expected[system_id] = {}
+            for hoard, indices in retained.items():
+                path = self.data_dir_path().joinpath("history").joinpath(system_id).joinpath(hoard.value)
+                files = list(os.listdir(path))
+                files.sort()
+                files = [file for (i, file) in enumerate(files) if i in indices and "last_paths" not in file]
+                expected[system_id][hoard] = files
+
+        self.targets = []
+        self.run_hoard("cleanup")
+
+        for system_id, retained in self.retained.items():
+            for hoard, _ in retained.items():
+                path = self.data_dir_path().joinpath("history").joinpath(system_id).joinpath(hoard.value)
+                retained_files = [file for file in os.listdir(path) if "last_paths" not in file]
+                expected_files = expected[system_id][hoard]
+                print(retained_files)
+                print(expected_files)
+                assert len(retained_files) == len(expected_files)
+                for file in expected_files:
+                    assert file in retained_files

--- a/ci-tests/tests/testers/hoard_tester.py
+++ b/ci-tests/tests/testers/hoard_tester.py
@@ -19,6 +19,12 @@ class Environment(str, Enum):
     Second = "second"
 
 
+class Hoard(str, Enum):
+    AnonDir = "anon_dir"
+    AnonFile = "anon_file"
+    Named = "named"
+
+
 class HoardFile(str, Enum):
     AnonFile = "anon_file"
     AnonDir = "anon_dir"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -16,6 +16,8 @@ pub enum Command {
     /// Loads all configuration for validation.
     /// If the configuration loads and builds, this command succeeds.
     Validate,
+    /// Cleans up the operation logs for all known systems.
+    Cleanup,
     /// Back up the given hoard(s).
     Backup {
         /// The name(s) of the hoard(s) to back up. Will back up all hoards if empty.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -165,6 +165,12 @@ impl Config {
             Command::Validate => {
                 tracing::info!("configuration is valid");
             }
+            Command::Cleanup => match crate::checkers::history::operation::cleanup_operations() {
+                Ok(count) => tracing::info!("cleaned up {} log files", count),
+                Err((count, err)) => {
+                    tracing::error!("error occurred after cleaning up {} files: {}", count, err);
+                }
+            },
             Command::Backup { hoards } => {
                 let hoards = self.get_hoards(hoards)?;
                 let mut checkers = Checkers::new(&hoards, true)?;


### PR DESCRIPTION
Resolves #37 

Adds `hoard cleanup`, which deletes extraneous operation logs to save space.