### PR TITLE
ci: get code coverage from python test scripts too (#40)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,30 @@ jobs:
         with:
           toolchain: nightly
           override: true
+          default: true
           components: llvm-tools-preview
+
+      - name: Install Grcov
+        uses: actions-rs/install@v0.1
+        with:
+          crate: grcov
+          version: latest
+          use-tool-cache: true
+
+      - name: Cargo Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zinstrument-coverage'
+          RUSTDOCFLAGS: '-Zinstrument-coverage'
+          LLVM_PROFILE_FILE: 'profraw/hoart-tests-%p-%m.profraw'
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
 
       - name: Cargo Test (Grcov)
         uses: actions-rs/cargo@v1
@@ -107,18 +130,21 @@ jobs:
           args: --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTFLAGS: '-Zinstrument-coverage'
+          RUSTDOCFLAGS: '-Zinstrument-coverage'
+          LLVM_PROFILE_FILE: 'profraw/hoart-tests-%p-%m.profraw'
+
+      - name: Run Integration Tests
+        run: python ci-tests/tests all
 
       - name: Run grcov
-        id: coverage
-        uses: actions-rs/grcov@v0.1
+        run: grcov profraw/*.profraw --binary-path target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ steps.coverage.outputs.report }}
+          files: coverage.lcov
 
   integration-tests:
     name: "Integration Tests"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,78 @@
+[tasks.clean-all]
+    script = """
+    cargo clean
+    rm -rf profraw
+    """
+
+[tasks.install-nightly]
+    ignore_errors = true
+    command = "rustup"
+    args = ["toolchain", "install", "nightly", "--component", "llvm-tools-preview", "--target", "x86_64-unknown-linux-musl"]
+
+[tasks.build-nightly]
+    install_crate = false
+    dependencies = ["install-nightly"]
+    command = "cargo"
+    args = ["+nightly", "build", "--target", "x86_64-unknown-linux-musl"]
+
+[tasks.test-nightly]
+    install_crate = false
+    dependencies = ["install-nightly"]
+    command = "cargo"
+    args = ["+nightly", "test", "--target", "x86_64-unknown-linux-musl"]
+    [tasks.test-nightly.env]
+        RUSTFLAGS="-Zinstrument-coverage"
+        LLVM_PROFILE_FILE="profraw/hoard-test-%p-%m.profraw"
+
+[tasks.integration-tests]
+    dependencies = ["build-nightly"]
+    script = """
+    mkdir -p ./profraw
+    sudo docker image build . -t hoard-tests
+    echo "Running tests"
+    sudo docker container run --rm -v $(pwd)/profraw:/hoard-tests/profraw:Z hoard-tests
+    echo "Ran tests"
+    """
+
+[tasks.grcov]
+    dependencies = ["test-nightly"]
+    install_crate = "grcov"
+    command = "grcov"
+    args = [
+        ".", "-s", ".", "-t", "html",
+        "--branch", "--ignore-not-existing",
+        "-o", "./target/debug/coverage/"
+    ]
+    [tasks.grcov.env]
+        CARGO_INCREMENTAL=0
+        RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        RUSTDOCFLAGS="-Cpanic=abort"
+
+[tasks.grcov-src]
+    dependencies = ["clean-all", "test-nightly", "integration-tests"]
+    #install_crate = "grcov"
+    script = """
+    grcov profraw/*.profraw --binary-path ./target/x86_64-unknown-linux-musl/debug -s . -t html --branch --ignore-not-existing -o ./target/debug/coverage
+    """
+    #command = "grcov"
+    #args = [
+    #    "*.profraw",
+    #    "--binary-path", "./target/debug",
+    #    "-s", ".", "-t", "html",
+    #    "--branch", "--ignore-not-existing",
+    #    "-o", "./target/debug/coverage/"
+    #]
+    [tasks.grcov-src.env]
+        RUSTFLAGS="-Zinstrument-coverage"
+        LLVM_PROFILE_FILE="default.profraw"
+        RUSTUP_TOOLCHAIN="nightly"
+
+[tasks.view-grcov-src]
+    dependencies = ["grcov-src"]
+    command = "xdg-open"
+    args = ["./target/debug/coverage/index.html"]
+
+[tasks.view-grcov]
+    dependencies = ["grcov"]
+    command = "xdg-open"
+    args = ["./target/debug/coverage/index.html"]

--- a/ci-tests/tests/__main__.py
+++ b/ci-tests/tests/__main__.py
@@ -55,6 +55,12 @@ if __name__ == "__main__":
         elif sys.argv[1] == "cleanup":
             print("Running cleanup test")
             LogCleanupTester().run_test()
+        elif sys.argv[1] == "all":
+            print("Running all tests")
+            LastPathsTester().run_test()
+            IgnoreFilterTester().run_test()
+            OperationCheckerTester().run_test()
+            LogCleanupTester().run_test()
         else:
             raise RuntimeError(f"Invalid argument {sys.argv[1]}")
     except Exception:

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -292,6 +292,7 @@ mod tests {
         use std::path::PathBuf;
 
         #[test]
+        #[serial_test::serial]
         fn env_vars_are_expanded() {
             let pile = Pile {
                 config: None,


### PR DESCRIPTION
Resolves #40.

This adds running the integration tests with the nightly compiler, which allows for generating profiling data from the integration tests and using that to determine code coverage.