### PR TITLE
#53: Error on invalid "config" item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,20 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +178,6 @@ dependencies = [
 name = "hoard"
 version = "0.3.1-prerelease"
 dependencies = [
- "chrono",
  "directories",
  "glob",
  "hostname",
@@ -209,6 +194,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "thiserror",
+ "time",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -274,15 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,9 +273,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -319,25 +296,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -718,13 +676,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "cde1cf55178e0293453ba2cca0d5f8392a922e52aa958aee9c28ed02becc6d03"
 dependencies = [
+ "itoa",
  "libc",
- "winapi",
+ "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "toml"
@@ -768,46 +734,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "5cf865b5ddc38e503a29c41c4843e616a73028ae18c637bc3eb2afaef4909c84"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
@@ -260,9 +260,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "lock_api"
@@ -394,9 +394,9 @@ checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -631,9 +631,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "hoard"
-version = "0.2.0"
+version = "0.3.1-prerelease"
 dependencies = [
  "chrono",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/Shadow53/hoard"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
 directories = "3.0.1"
 glob = "0.3"
 hostname = "0.3"
@@ -23,9 +22,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3.21"
 thiserror = "1.0.24"
+time = { version = "0.3", default-features = false, features = ["formatting", "macros", "serde", "std"] }
 toml = "0.5.8"
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", features = ["ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt", "env-filter", "smallvec", "std"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 which = "4.1"
 

--- a/ci-tests/env-string-named-config.toml
+++ b/ci-tests/env-string-named-config.toml
@@ -1,0 +1,5 @@
+[envs.config]
+    env = [{ var = "CI" }]
+
+[hoards.a_hoard]
+    "config" = "/tmp"

--- a/ci-tests/hoard-named-config.toml
+++ b/ci-tests/hoard-named-config.toml
@@ -1,0 +1,6 @@
+[envs.ci]
+    env = [{ var = "CI" }]
+
+# invalid hoard name
+[hoards.config]
+    "ci" = "/does/not/exist"

--- a/ci-tests/pile-named-config.toml
+++ b/ci-tests/pile-named-config.toml
@@ -1,0 +1,8 @@
+[envs.valid]
+    env = []
+
+[hoards.invalid_named_pile]
+[hoards.invalid_named_pile.config]
+    "valid" = "/tmp"
+#[hoards.invalid_named_pile.other]
+    #"valid" = "/tmp/something"

--- a/ci-tests/tests/testers/correct_errors.py
+++ b/ci-tests/tests/testers/correct_errors.py
@@ -2,11 +2,28 @@ from .hoard_tester import HoardTester
 
 
 class CorrectErrorsTester(HoardTester):
-    def __init__(self):
-        super()
+    def _run_missing_parent_test(self):
         self.reset(config_file="missing-parent-config.toml")
-
-    def run_test(self):
-        self.targets = ["missing"]
         result = self.run_hoard("backup", allow_failure=True, capture_output=True)
         assert b"source path does not exist" in result.stdout
+
+    def _run_env_string_named_config_test(self):
+        self.reset(config_file="env-string-named-config.toml")
+        result = self.run_hoard("validate", allow_failure=True, capture_output=True)
+        assert b'the name "config" is not allowed at: ["envs", "config"]' in result.stdout
+
+    def _run_hoard_named_config_test(self):
+        self.reset(config_file="hoard-named-config.toml")
+        result = self.run_hoard("validate", allow_failure=True, capture_output=True)
+        assert b'the name "config" is not allowed at: ["hoards", "config"]' in result.stdout
+
+    def _run_pile_named_config_test(self):
+        self.reset(config_file="pile-named-config.toml")
+        result = self.run_hoard("validate", allow_failure=True, capture_output=True)
+        assert b'expected "config" to be a pile config: at ["hoards", "invalid_named_pile", "config"]' in result.stdout
+
+    def run_test(self):
+        self._run_missing_parent_test()
+        self._run_pile_named_config_test()
+        self._run_env_string_named_config_test()
+        self._run_hoard_named_config_test()

--- a/src/checkers/history/last_paths.rs
+++ b/src/checkers/history/last_paths.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::{fs, io};
 use thiserror::Error;
+use time::OffsetDateTime;
 
 const FILE_NAME: &str = "last_paths.json";
 
@@ -139,7 +140,7 @@ impl Default for LastPaths {
 /// hoard.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HoardPaths {
-    timestamp: chrono::DateTime<chrono::Utc>,
+    timestamp: OffsetDateTime,
     piles: PilePaths,
 }
 
@@ -192,7 +193,7 @@ where
 {
     fn from(val: T) -> Self {
         Self {
-            timestamp: chrono::offset::Utc::now(),
+            timestamp: OffsetDateTime::now_utc(),
             piles: val.into(),
         }
     }
@@ -201,7 +202,7 @@ where
 impl HoardPaths {
     /// Get the timestamp of the last operation on this hoard.
     #[must_use]
-    pub fn time(&self) -> &chrono::DateTime<chrono::Utc> {
+    pub fn time(&self) -> &OffsetDateTime {
         &self.timestamp
     }
 

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -34,23 +34,23 @@ pub enum Error {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SymmetricEncryption {
     /// Raw password.
-    #[serde(rename = "encrypt_pass")]
+    #[serde(rename = "password")]
     Password(String),
     /// Command whose first line of output to stdout is the password.
-    #[serde(rename = "encrypt_pass_cmd")]
+    #[serde(rename = "password_cmd")]
     PasswordCmd(Vec<String>),
 }
 
 /// Configuration for asymmetric (public key) encryption.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AsymmetricEncryption {
-    #[serde(rename = "encrypt_pub_key")]
+    #[serde(rename = "public_key")]
     public_key: String,
 }
 
 /// Configuration for hoard/pile encryption.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "encrypt", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Encryption {
     /// Symmetric encryption.
     Symmetric(SymmetricEncryption),
@@ -63,7 +63,7 @@ pub enum Encryption {
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// The [`Encryption`] configuration for a pile.
-    #[serde(default)]
+    #[serde(default, rename = "encrypt")]
     pub encryption: Option<Encryption>,
     /// A list of glob patterns matching files to ignore.
     #[serde(default)]
@@ -364,15 +364,25 @@ mod tests {
                     Token::Map { len: None },
                     Token::Str("config"),
                     Token::Some,
-                    Token::Map { len: None },
+                    Token::Struct {
+                        name: "Config",
+                        len: 2,
+                    },
                     Token::Str("encrypt"),
+                    Token::Some,
+                    Token::Struct {
+                        name: "AsymmetricEncryption",
+                        len: 2,
+                    },
+                    Token::Str("type"),
                     Token::Str("asymmetric"),
-                    Token::Str("encrypt_pub_key"),
+                    Token::Str("public_key"),
                     Token::Str("public key"),
+                    Token::StructEnd,
                     Token::Str("ignore"),
                     Token::Seq { len: Some(0) },
                     Token::SeqEnd,
-                    Token::MapEnd,
+                    Token::StructEnd,
                     Token::Str("bar_env|foo_env"),
                     Token::Str("/some/path"),
                     Token::MapEnd,
@@ -437,15 +447,22 @@ mod tests {
                     Token::Map { len: None },
                     Token::Str("config"),
                     Token::Some,
-                    Token::Map { len: None },
+                    Token::Struct {
+                        name: "Config",
+                        len: 2,
+                    },
                     Token::Str("encrypt"),
+                    Token::Some,
+                    Token::Map { len: Some(2) },
+                    Token::Str("type"),
                     Token::Str("symmetric"),
-                    Token::Str("encrypt_pass"),
+                    Token::Str("password"),
                     Token::Str("correcthorsebatterystaple"),
+                    Token::MapEnd,
                     Token::Str("ignore"),
                     Token::Seq { len: Some(0) },
                     Token::SeqEnd,
-                    Token::MapEnd,
+                    Token::StructEnd,
                     Token::Str("item1"),
                     Token::Map { len: None },
                     Token::Str("config"),

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -60,9 +60,10 @@ pub enum Encryption {
 
 /// Hoard/Pile configuration.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The [`Encryption`] configuration for a pile.
-    #[serde(flatten)]
+    #[serde(default)]
     pub encryption: Option<Encryption>,
     /// A list of glob patterns matching files to ignore.
     #[serde(default)]


### PR DESCRIPTION
This adds a manual check that the name "config" is not used anywhere where a valid Pile config is expected or will cause confusion with the same.