### PR TITLE
refactor: parse glob patterns when reading config, not after

### DIFF
--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -51,28 +51,12 @@ impl Filter for Filters {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error::Error as _;
-
-    #[test]
-    fn test_error_derives() {
-        let config = Config {
-            encryption: None,
-            ignore: vec!["invalid**".to_string()],
-        };
-        let ignore_error =
-            ignore::IgnoreFilter::new(&config).expect_err("config should be invalid");
-        let error = Error::from(ignore_error);
-        assert!(format!("{:?}", error).contains("Ignore"));
-        assert!(format!("{:?}", error).contains("InvalidGlob"));
-        assert!(error.source().is_some());
-        assert!(error.to_string().contains("in the ignore filter"));
-    }
 
     #[test]
     fn test_filters_derives() {
         let config = Config {
             encryption: None,
-            ignore: vec!["valid/**".to_string()],
+            ignore: vec![glob::Pattern::new("valid/**").unwrap()],
         };
         let filters = Filters::new(&config).expect("config should be valid");
         assert!(format!("{:?}", filters).contains("Filters"));


### PR DESCRIPTION
Resolves #58 by parsing ignore patterns as `glob::Pattern` when the configuration file is deserialized instead of when the ignore patterns get used.