### PR TITLE
refactor: reuse operation logs for backup/restore

### DIFF
--- a/src/checkers/history/operation/mod.rs
+++ b/src/checkers/history/operation/mod.rs
@@ -101,7 +101,9 @@ pub trait OperationImpl {
     /// Returns [`Error::UpgradeRequired`] if the operation version is too old to support this
     /// function.
     fn hoard_operations_iter<'a>(
-        &'a self, _hoard_path: &HoardPath, _hoard: &Hoard,
+        &'a self,
+        _hoard_path: &HoardPath,
+        _hoard: &Hoard,
     ) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
         Err(Error::UpgradeRequired)
     }
@@ -155,7 +157,11 @@ impl OperationImpl for OperationVersion {
         }
     }
 
-    fn hoard_operations_iter<'a>(&'a self, hoard_root: &HoardPath, hoard: &Hoard) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
+    fn hoard_operations_iter<'a>(
+        &'a self,
+        hoard_root: &HoardPath,
+        hoard: &Hoard,
+    ) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
         match &self {
             OperationVersion::V1(v1) => v1.hoard_operations_iter(hoard_root, hoard),
             OperationVersion::V2(v2) => v2.hoard_operations_iter(hoard_root, hoard),
@@ -200,7 +206,11 @@ impl OperationImpl for Operation {
         self.0.all_files_with_checksums()
     }
 
-    fn hoard_operations_iter<'a>(&'a self, hoard_root: &HoardPath, hoard: &Hoard) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
+    fn hoard_operations_iter<'a>(
+        &'a self,
+        hoard_root: &HoardPath,
+        hoard: &Hoard,
+    ) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
         self.0.hoard_operations_iter(hoard_root, hoard)
     }
 }

--- a/src/checkers/history/operation/mod.rs
+++ b/src/checkers/history/operation/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::checkers::history::operation::util::TIME_FORMAT;
 use crate::checkers::Checker;
+use crate::hoard::iter::ItemOperation;
 use crate::hoard::{Direction, Hoard};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -93,6 +94,17 @@ pub trait OperationImpl {
     /// An iterator over all files that exist within this operation log, not including any that
     /// were deleted.
     fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item = OperationFileInfo> + 'a>;
+    /// Returns an iterator of the file operations represented by this operation object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UpgradeRequired`] if the operation version is too old to support this
+    /// function.
+    fn hoard_operations_iter<'a>(
+        &'a self, _hoard_path: &HoardPath, _hoard: &Hoard,
+    ) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
+        Err(Error::UpgradeRequired)
+    }
 }
 
 impl OperationImpl for OperationVersion {
@@ -142,6 +154,13 @@ impl OperationImpl for OperationVersion {
             OperationVersion::V2(two) => two.all_files_with_checksums(),
         }
     }
+
+    fn hoard_operations_iter<'a>(&'a self, hoard_root: &HoardPath, hoard: &Hoard) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
+        match &self {
+            OperationVersion::V1(v1) => v1.hoard_operations_iter(hoard_root, hoard),
+            OperationVersion::V2(v2) => v2.hoard_operations_iter(hoard_root, hoard),
+        }
+    }
 }
 
 /// A wrapper struct for any supported operation log version.
@@ -179,6 +198,10 @@ impl OperationImpl for Operation {
 
     fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item = OperationFileInfo> + 'a> {
         self.0.all_files_with_checksums()
+    }
+
+    fn hoard_operations_iter<'a>(&'a self, hoard_root: &HoardPath, hoard: &Hoard) -> Result<Box<dyn Iterator<Item = ItemOperation> + 'a>, Error> {
+        self.0.hoard_operations_iter(hoard_root, hoard)
     }
 }
 

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -114,4 +114,8 @@ impl Checkers {
         }
         Ok(())
     }
+
+    pub(crate) fn get_operation_for<'a>(&'a self, hoard_name: &HoardName) -> Option<&'a Operation> {
+        self.operations.get(hoard_name)
+    }
 }

--- a/src/command/backup_restore.rs
+++ b/src/command/backup_restore.rs
@@ -1,8 +1,8 @@
-use crate::checkers::{Checkers, Error as ConsistencyError};
-use crate::hoard::iter::{Error as IterError, OperationIter, OperationType};
+use crate::checkers::{Checkers, Error as ConsistencyError, history::operation::OperationImpl};
+use crate::hoard::iter::{Error as IterError, ItemOperation};
 use crate::hoard::{Direction, Hoard};
 use crate::newtypes::HoardName;
-use crate::paths::HoardPath;
+use crate::paths::{HoardPath, RelativePath};
 use std::fs;
 use thiserror::Error;
 
@@ -59,11 +59,13 @@ fn backup_or_restore<'a>(
             Direction::Restore => tracing::info!(hoard=%name, "restoring"),
         }
 
-        for operation in OperationIter::new(hoards_root, name.clone(), hoard, direction)? {
-            let operation = operation?;
+        let hoard_prefix = hoards_root.join(&RelativePath::from(name));
+        let op = checkers.get_operation_for(name).expect("operation should exist for hoard");
+        let iter = op.hoard_operations_iter(&hoard_prefix, hoard).map_err(ConsistencyError::Operation)?;
+        for operation in iter {
             tracing::trace!("found operation: {:?}", operation);
             match operation {
-                OperationType::Create(file) | OperationType::Modify(file) => {
+                ItemOperation::Create(file) | ItemOperation::Modify(file) => {
                     let (src, dest) = match direction {
                         Direction::Backup => {
                             (file.system_path().as_ref(), file.hoard_path().as_ref())
@@ -94,7 +96,7 @@ fn backup_or_restore<'a>(
                         return Err(Error::IO(err));
                     }
                 }
-                OperationType::Delete(file) => {
+                ItemOperation::Delete(file) => {
                     let to_remove = match direction {
                         Direction::Backup => file.hoard_path().as_ref(),
                         Direction::Restore => file.system_path().as_ref(),
@@ -105,7 +107,7 @@ fn backup_or_restore<'a>(
                         return Err(Error::IO(err));
                     }
                 }
-                OperationType::Nothing(file) => {
+                ItemOperation::Nothing(file) => {
                     tracing::debug!("file {} is unchanged", file.system_path().display());
                 }
             }

--- a/src/command/backup_restore.rs
+++ b/src/command/backup_restore.rs
@@ -1,4 +1,4 @@
-use crate::checkers::{Checkers, Error as ConsistencyError, history::operation::OperationImpl};
+use crate::checkers::{history::operation::OperationImpl, Checkers, Error as ConsistencyError};
 use crate::hoard::iter::{Error as IterError, ItemOperation};
 use crate::hoard::{Direction, Hoard};
 use crate::newtypes::HoardName;
@@ -60,8 +60,12 @@ fn backup_or_restore<'a>(
         }
 
         let hoard_prefix = hoards_root.join(&RelativePath::from(name));
-        let op = checkers.get_operation_for(name).expect("operation should exist for hoard");
-        let iter = op.hoard_operations_iter(&hoard_prefix, hoard).map_err(ConsistencyError::Operation)?;
+        let op = checkers
+            .get_operation_for(name)
+            .expect("operation should exist for hoard");
+        let iter = op
+            .hoard_operations_iter(&hoard_prefix, hoard)
+            .map_err(ConsistencyError::Operation)?;
         for operation in iter {
             tracing::trace!("found operation: {:?}", operation);
             match operation {

--- a/src/hoard/iter/mod.rs
+++ b/src/hoard/iter/mod.rs
@@ -10,7 +10,7 @@ mod operation;
 pub(crate) use crate::hoard_item::HoardItem;
 pub(crate) use diff_files::{DiffSource, HoardDiffIter, HoardFileDiff};
 use macros::propagate_error;
-pub(crate) use operation::{OperationIter, ItemOperation};
+pub(crate) use operation::{ItemOperation, OperationIter};
 
 mod macros {
     macro_rules! propagate_error {

--- a/src/hoard/iter/mod.rs
+++ b/src/hoard/iter/mod.rs
@@ -10,7 +10,7 @@ mod operation;
 pub(crate) use crate::hoard_item::HoardItem;
 pub(crate) use diff_files::{DiffSource, HoardDiffIter, HoardFileDiff};
 use macros::propagate_error;
-pub(crate) use operation::{OperationIter, OperationType};
+pub(crate) use operation::{OperationIter, ItemOperation};
 
 mod macros {
     macro_rules! propagate_error {

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod pile_config;
 use crate::checkers::history::last_paths::HoardPaths;
 use crate::filters::Error as FilterError;
 use crate::newtypes::{NonEmptyPileName, PileName};
-use crate::paths::{SystemPath, RelativePath, HoardPath};
+use crate::paths::{HoardPath, RelativePath, SystemPath};
 pub use pile_config::Config as PileConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -120,20 +120,25 @@ impl Hoard {
     ///
     /// The [`HoardPath`] and [`SystemPath`] represent the relevant prefix/root path for the given pile.
     #[must_use]
-    pub fn get_paths(&self, hoards_root: HoardPath) -> Box<dyn Iterator<Item = (PileName, HoardPath, SystemPath)>> {
+    pub fn get_paths(
+        &self,
+        hoards_root: HoardPath,
+    ) -> Box<dyn Iterator<Item = (PileName, HoardPath, SystemPath)>> {
         match self {
             Hoard::Anonymous(pile) => match pile.path.clone() {
                 None => Box::new(std::iter::empty()),
                 Some(path) => Box::new(std::iter::once({
                     (PileName::anonymous(), hoards_root, path)
-                }))
+                })),
             },
-            Hoard::Named(named) => Box::new(named.piles.clone().into_iter().filter_map(move |(name, pile)| {
-                pile.path.map(|path| {
-                    let pile_hoard_root = hoards_root.join(&RelativePath::from(&name));
-                    (name.into(), pile_hoard_root, path)
-                })
-            })),
+            Hoard::Named(named) => Box::new(named.piles.clone().into_iter().filter_map(
+                move |(name, pile)| {
+                    pile.path.map(|path| {
+                        let pile_hoard_root = hoards_root.join(&RelativePath::from(&name));
+                        (name.into(), pile_hoard_root, path)
+                    })
+                },
+            )),
         }
     }
 }

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -7,8 +7,8 @@ pub(crate) mod pile_config;
 
 use crate::checkers::history::last_paths::HoardPaths;
 use crate::filters::Error as FilterError;
-use crate::newtypes::NonEmptyPileName;
-use crate::paths::SystemPath;
+use crate::newtypes::{NonEmptyPileName, PileName};
+use crate::paths::{SystemPath, RelativePath, HoardPath};
 pub use pile_config::Config as PileConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -104,7 +104,7 @@ pub enum Hoard {
 impl Hoard {
     /// Returns a [`HoardPaths`] based on this `Hoard`.
     #[must_use]
-    pub fn get_paths(&self) -> HoardPaths {
+    pub fn get_last_paths(&self) -> HoardPaths {
         match self {
             Hoard::Anonymous(pile) => pile.path.clone().into(),
             Hoard::Named(piles) => piles
@@ -113,6 +113,27 @@ impl Hoard {
                 .filter_map(|(key, val)| val.path.clone().map(|path| (key.clone(), path)))
                 .collect::<HashMap<_, _>>()
                 .into(),
+        }
+    }
+
+    /// Returns an iterator over all piles with associates paths.
+    ///
+    /// The [`HoardPath`] and [`SystemPath`] represent the relevant prefix/root path for the given pile.
+    #[must_use]
+    pub fn get_paths(&self, hoards_root: HoardPath) -> Box<dyn Iterator<Item = (PileName, HoardPath, SystemPath)>> {
+        match self {
+            Hoard::Anonymous(pile) => match pile.path.clone() {
+                None => Box::new(std::iter::empty()),
+                Some(path) => Box::new(std::iter::once({
+                    (PileName::anonymous(), hoards_root, path)
+                }))
+            },
+            Hoard::Named(named) => Box::new(named.piles.clone().into_iter().filter_map(move |(name, pile)| {
+                pile.path.map(|path| {
+                    let pile_hoard_root = hoards_root.join(&RelativePath::from(&name));
+                    (name.into(), pile_hoard_root, path)
+                })
+            })),
         }
     }
 }


### PR DESCRIPTION
Resolves #107.

Previous code iterated over files twice, which invoked more I/O than necessary.

This creates a couple functions that return an iterator that can be used without invoking disk I/O.