### PR TITLE
refactor: replace hoards_root with config_dir and data_dir

### DIFF
--- a/book/src/cli/flags-subcommands.md
+++ b/book/src/cli/flags-subcommands.md
@@ -5,7 +5,8 @@ Flags can be used with any subcommand and must be specified *before* any subcomm
 - `--help`: View the program's help message.
 - `-V/--version`: Print the installed version of `hoard`.
 - `-c/--config-file`: Path to (non-default) configuration file.
-- `-h/--hoards-root`: Path to (non-default) hoards root directory.
+- `--data-dir`: Path to (non-default) hoards data directory.
+- `--config-dir`: Path to (non-default) hoards config directory.
 
 # Subcommands
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,8 +32,6 @@ pub enum Error {
 pub struct Config {
     /// The command to run.
     pub command: Command,
-    /// The root directory to backup/restore hoards from.
-    pub hoards_root: HoardPath,
     /// Path to a configuration file.
     pub config_file: PathBuf,
     /// All of the configured hoards.
@@ -87,7 +85,7 @@ impl Config {
     /// The path to the configured hoards root.
     #[must_use]
     pub fn get_hoards_root_path(&self) -> HoardPath {
-        self.hoards_root.clone()
+        crate::paths::hoards_dir()
     }
 
     fn get_hoards<'a>(
@@ -146,14 +144,14 @@ impl Config {
                 command::run_cleanup()?;
             }
             Command::Backup { hoards } => {
-                let hoards_root = self.get_hoards_root_path();
+                let data_dir = self.get_hoards_root_path();
                 let hoards = self.get_hoards(hoards)?;
-                command::run_backup(&hoards_root, hoards, self.force)?;
+                command::run_backup(&data_dir, hoards, self.force)?;
             }
             Command::Restore { hoards } => {
-                let hoards_root = self.get_hoards_root_path();
+                let data_dir = self.get_hoards_root_path();
                 let hoards = self.get_hoards(hoards)?;
-                command::run_restore(&hoards_root, hoards, self.force)?;
+                command::run_restore(&data_dir, hoards, self.force)?;
             }
             Command::Upgrade => {
                 command::run_upgrade()?;
@@ -193,16 +191,6 @@ mod tests {
             config.get_config_file_path(),
             config.config_file,
             "should return config file path"
-        );
-    }
-
-    #[test]
-    fn test_config_get_saves_root_returns_saves_root_path() {
-        let config = Config::default();
-        assert_eq!(
-            config.get_hoards_root_path(),
-            config.hoards_root,
-            "should return saves root path"
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,6 @@ pub use self::builder::Builder;
 use crate::command::{self, Command};
 use crate::hoard::{self, Hoard};
 use crate::newtypes::HoardName;
-use crate::paths::HoardPath;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -82,12 +81,6 @@ impl Config {
         self.config_file.clone()
     }
 
-    /// The path to the configured hoards root.
-    #[must_use]
-    pub fn get_hoards_root_path(&self) -> HoardPath {
-        crate::paths::hoards_dir()
-    }
-
     fn get_hoards<'a>(
         &'a self,
         hoards: &'a [HoardName],
@@ -121,13 +114,13 @@ impl Config {
         match &self.command {
             Command::Status => {
                 let iter = self.hoards.iter();
-                command::run_status(&self.get_hoards_root_path(), iter)?;
+                command::run_status(&crate::paths::hoards_dir(), iter)?;
             }
             Command::Diff { hoard, verbose } => {
                 command::run_diff(
                     self.get_hoard(hoard)?,
                     hoard,
-                    &self.get_hoards_root_path(),
+                    &crate::paths::hoards_dir(),
                     *verbose,
                 )?;
             }
@@ -144,12 +137,12 @@ impl Config {
                 command::run_cleanup()?;
             }
             Command::Backup { hoards } => {
-                let data_dir = self.get_hoards_root_path();
+                let data_dir = crate::paths::hoards_dir();
                 let hoards = self.get_hoards(hoards)?;
                 command::run_backup(&data_dir, hoards, self.force)?;
             }
             Command::Restore { hoards } => {
-                let data_dir = self.get_hoards_root_path();
+                let data_dir = crate::paths::hoards_dir();
                 let hoards = self.get_hoards(hoards)?;
                 command::run_restore(&data_dir, hoards, self.force)?;
             }

--- a/src/dirs/mod.rs
+++ b/src/dirs/mod.rs
@@ -1,5 +1,5 @@
 //! Functions to determine special folders for Hoard to work with on different platforms.
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 
 #[cfg(unix)]
 mod unix;
@@ -22,6 +22,10 @@ pub const TLD: &str = "com";
 pub const COMPANY: &str = "shadow53";
 /// The Project Name portion of the application identifier.
 pub const PROJECT: &str = "hoard";
+/// The environment variable that takes precendence over data dir detection.
+pub const DATA_DIR_ENV: &str = "HOARD_DATA_DIR";
+/// The environment variable that takes precendence over config dir detection.
+pub const CONFIG_DIR_ENV: &str = "HOARD_CONFIG_DIR";
 
 #[inline]
 fn path_from_env(var: &str) -> Option<PathBuf> {
@@ -40,6 +44,8 @@ pub fn home_dir() -> PathBuf {
 
 /// Returns Hoard's configuration directory for the current user.
 ///
+/// Returns the contents of `HOARD_CONFIG_DIR`, if set, otherwise:
+///
 /// - Windows: `{appdata}/shadow53/hoard/config` where `{appdata}` is the "known folder"
 ///   `FOLDERID_RoamingAppData` or the value of `%APPDATA%`.
 /// - macOS: `${XDG_CONFIG_HOME}/hoard`, if `XDG_CONFIG_HOME` is set, otherwise
@@ -48,7 +54,7 @@ pub fn home_dir() -> PathBuf {
 #[must_use]
 #[inline]
 pub fn config_dir() -> PathBuf {
-    sys::config_dir()
+    path_from_env(CONFIG_DIR_ENV).unwrap_or_else(sys::config_dir)
 }
 
 /// Returns Hoard's data directory for the current user.
@@ -61,5 +67,19 @@ pub fn config_dir() -> PathBuf {
 #[must_use]
 #[inline]
 pub fn data_dir() -> PathBuf {
-    sys::data_dir()
+    path_from_env(DATA_DIR_ENV).unwrap_or_else(sys::data_dir)
+}
+
+/// Set the environment variable that overrides Hoard's config directory.
+///
+/// See [`CONFIG_DIR_ENV`].
+pub fn set_config_dir(path: &Path) {
+    std::env::set_var(CONFIG_DIR_ENV, path);
+}
+
+/// Set the environment variable that overrides Hoard's data directory.
+///
+/// See [`DATA_DIR_ENV`].
+pub fn set_data_dir(path: &Path) {
+    std::env::set_var(DATA_DIR_ENV, path);
 }

--- a/src/dirs/mod.rs
+++ b/src/dirs/mod.rs
@@ -83,3 +83,31 @@ pub fn set_config_dir(path: &Path) {
 pub fn set_data_dir(path: &Path) {
     std::env::set_var(DATA_DIR_ENV, path);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_env_config_dir() {
+        env::remove_var(CONFIG_DIR_ENV);
+        let original = config_dir();
+        let new_path = PathBuf::from("/env/config/dir");
+        assert_ne!(original, new_path);
+        set_config_dir(&new_path);
+        assert_eq!(new_path.as_os_str(), env::var_os(CONFIG_DIR_ENV).unwrap());
+        assert_eq!(new_path, config_dir());
+    }
+
+    #[test]
+    fn test_env_data_dir() {
+        env::remove_var(DATA_DIR_ENV);
+        let original = data_dir();
+        let new_path = PathBuf::from("/env/data/dir");
+        assert_ne!(original, new_path);
+        set_data_dir(&new_path);
+        assert_eq!(new_path.as_os_str(), env::var_os(DATA_DIR_ENV).unwrap());
+        assert_eq!(new_path, data_dir());
+    }
+}

--- a/src/dirs/mod.rs
+++ b/src/dirs/mod.rs
@@ -1,5 +1,5 @@
 //! Functions to determine special folders for Hoard to work with on different platforms.
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 mod unix;

--- a/src/newtypes/hoard_name.rs
+++ b/src/newtypes/hoard_name.rs
@@ -76,10 +76,10 @@ mod tests {
                 (Ok(name), Err(err)) => panic!("expected error {:?}, got success {:?}", err, name),
                 (Err(err), Ok(name)) => panic!("expected success {:?}, got error {:?}", name, err),
                 (Ok(name), Ok(expected)) => {
-                    assert_eq!(name, expected, "expected {} but got {}", expected, name)
+                    assert_eq!(name, expected, "expected {} but got {}", expected, name);
                 }
                 (Err(err), Err(expected)) => {
-                    assert_eq!(err, expected, "expected {:?} but got {:?}", expected, err)
+                    assert_eq!(err, expected, "expected {:?} but got {:?}", expected, err);
                 }
             }
         }

--- a/src/newtypes/pile_name.rs
+++ b/src/newtypes/pile_name.rs
@@ -159,7 +159,7 @@ mod tests {
             let result = s.parse();
             match (expected, result) {
                 (Ok(name1), Ok(name2)) => {
-                    assert_eq!(name1, name2, "expected {} but got {}", name1, name2)
+                    assert_eq!(name1, name2, "expected {} but got {}", name1, name2);
                 }
                 (Err(err1), Err(err2)) => match (&err1, &err2) {
                     (Error::EmptyName, Error::EmptyName) => {}
@@ -175,10 +175,10 @@ mod tests {
                     }
                 },
                 (Ok(name), Err(err)) => {
-                    panic!("expected successful parse {:?}, got error {:?}", name, err)
+                    panic!("expected successful parse {:?}, got error {:?}", name, err);
                 }
                 (Err(err), Ok(name)) => {
-                    panic!("expected error {:?}, got success with {:?}", err, name)
+                    panic!("expected error {:?}, got success with {:?}", err, name);
                 }
             }
         }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -366,7 +366,7 @@ mod tests {
             let valid_path =
                 hoards_dir().join(&RelativePath::try_from(PathBuf::from("valid")).unwrap());
             let valid_str = valid_path.as_ref().to_str().unwrap();
-            let path = HoardPath::from_str(&valid_str).unwrap();
+            let path = HoardPath::from_str(valid_str).unwrap();
             assert_eq!(path, valid_path);
         }
     }


### PR DESCRIPTION
Resolves #97.

This replaces the `hoards_root` config item with `config_dir` and `data_dir`, for consistency reasons.

`hoards_root` only applied to the actual hoard/pile files, not the entire data directory. This meant that the history logs were not stored next to hoard files in a custom directory, even though both should be synced together.

This also enables easier overriding of config/data dirs by introducing the `HOARD_CONFIG_DIR` and `HOARD_DATA_DIR` environment variables.