### PR TITLE
feat: handle file permissions based on config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,8 +112,8 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: '1'
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zinstrument-coverage'
-          RUSTDOCFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-Cinstrument-coverage'
+          RUSTDOCFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'profraw/hoard-cargo-tests-%p-%m.profraw'
 
       - name: Run grcov
@@ -126,7 +126,7 @@ jobs:
           --excl-br-start "(grcov: ignore-start|mod tests)" --excl-start "(grcov: ignore-start|mod tests)" \
           --excl-br-stop "grcov: ignore-end" --excl-stop "grcov: ignore-end"
         env:
-          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTFLAGS: "-Cinstrument-coverage"
           RUSTC_BOOTSTRAP: "1"
           RUSTUP_TOOLCHAIN: "stable"
           HOARD_LOG: "trace"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,6 @@
 [tasks.clean-all]
     script = """
-    #cargo clean
+    cargo clean
     rm -rf profraw
     """
 
@@ -52,7 +52,7 @@
     """
 
 [tasks.grcov]
-    dependencies = ["clean-all", "test-nextest"]
+    dependencies = ["clean-all", "test-single-thread"]
     # Using `script` is necessary to get the glob expansion
     script = """
     grcov profraw/*.profraw --binary-path ./target/debug \
@@ -75,7 +75,7 @@
         EXCLUDE_LONE_CLOSING_BRACE="^\\s*\\}\\s*$"
 
 [tasks.view-grcov]
-    dependencies = ["grcov"]
+    dependencies = ["clean-all", "grcov"]
     command = "xdg-open"
     args = ["./target/debug/coverage/index.html"]
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,3 +19,5 @@
 - [Configuration File](./config/README.md)
     - [Environments](./config/envs.md)
     - [Hoards and Piles](./config/hoards-piles.md)
+
+- [File Permissions](./permissions.md)

--- a/book/src/config/hoards-piles.md
+++ b/book/src/config/hoards-piles.md
@@ -118,3 +118,74 @@ to ignore. These lists will be merged across all levels of configuration.
     "bar" = "/another/named/path"
 ```
 
+### File Permissions
+
+> For a general discussion of file/folder permission support in Hoard, including
+> Windows-specific limitations, see [this page](../../permissions.md).
+
+Hoard supports setting permissions separately for files and folders, using `file_permissions`
+and `folder_permissions`, respectively. These can be specified in two different ways: a "mode"
+and boolean flags.
+
+#### Mode
+
+A "mode" is an octal (base 8) integer representing read, write, and execute permissions for the
+owning user, users in the owning "group", and all other users. See the
+[Wikipedia article](https://en.wikipedia.org/wiki/Unix_file_types#Representations) for more.
+
+You can specify a "mode" in TOML by prefixing the number with `0o`. For example, a common file
+mode is `0o644` (read/write for the owner user, readonly for everyone else).
+
+```toml
+[config]
+    file_permissions = 0o644
+```
+
+If using a "mode" is too confusing, you can also use a set of boolean flags: just set these to
+`true` or `false`:
+
+#### Flags
+
+> Note: only `is_writable` is supported on Windows. All other flags are ignored.
+> Note 2: "others" in the context of these boolean flags are a combination of the "group" and "other"
+> values from a file "mode".
+
+- `is_readable`: the owning user can read the contents of the file or folder. This should not be
+  set to `false` and is provided for completeness' sake.
+- `is_writable`: the owning user can modify and delete the file or folder.
+- `is_executable`: this has different meanings depending on whether it applies to files or folders:
+  - `true` for files means that the user can run the file as an executable program.
+  - `true` for folders means that the user can list the contents of the folder.
+  - In short, this should always be `true` for folders.
+
+- `others_can_read`: like `is_readable` but for non-owner users.
+- `others_can_write`: like `is_writable` but for non-owner users.
+- `others_can_execute`: like `is_executable` but for non-owner users.
+
+```toml
+# ... snip env definitions of "foo" and "bar" ...
+
+# Top-level config, applies to all hoards
+[config]
+    # These represent the current defaults used by Hoard:
+    # owner-only access.
+    file_permissions = 0o600
+    folder_permissions = 0o700
+
+[hoards]
+[hoards.anon_hoard]
+    "foo" = "/some/path"
+    "bar" = "/some/other/path"
+[hoards.anon_hoard.config.file_permissions]
+    # Equivalent to a 0o644 mode
+    is_readable = true
+    is_writable = true
+    others_can_read = true
+[hoards.anon_hoard.config.folder_permissions]
+    # Equivalent to a 0o755 mode
+    is_readable = true
+    is_writable = true
+    is_executable = true
+    others_can_read = true
+    others_can_execute = true
+```

--- a/book/src/permissions.md
+++ b/book/src/permissions.md
@@ -1,0 +1,34 @@
+# File Permissions in Hoard
+
+Hoard supports the three most popular desktop operating systems: Windows, macOS, and Linux.
+One of these uses a very different implementation of file permissions compared to the others
+-- this is why Rust only provides one bit of support for all platforms: whether something is
+[readonly](https://doc.rust-lang.org/stable/std/fs/struct.Permissions.html) or not.
+
+Previous versions of Hoard ignored this and just hoped things would stay consistent. With the
+release of 0.5.0, though, Hoard added support for setting file permissions on restore.
+
+## Configuration
+
+As of 0.5.0, Hoard supports setting [configurable permissions](config/hoards-piles.md#file-permissions)
+on files and folders on a `hoard restore`.
+
+## When Permissions Are Set
+
+Permissions are set on both backup and restore.
+
+> Note: discussion of what permissions are set only apply to Unix-like systems, as Windows only
+> supports `readonly`, which always defaults to `false` for the owning user.
+
+### Backing Up
+
+When backing up files, all files are given a mode of `0600` and all folders are given a mode of `0700`,
+i.e., owner-only access. This is done to provide a little extra filesystem-based security, since the
+permissions in the Hoard do not affect the permissions given on restore.
+
+### Restoring
+
+When restoring files, all files and folders are given the permissions specified in the most-specific
+parent pile config. That is, the usual precedence holds, and permissions are not merged.
+
+If no permissions are configured, the defaults are `0600` for files and `0700` for folders.

--- a/src/checkers/history/operation/v2.rs
+++ b/src/checkers/history/operation/v2.rs
@@ -242,13 +242,13 @@ impl OperationImpl for OperationV2 {
                 });
 
                 let (u_pile_name, u_hoard_path, u_system_path) =
-                    (pile_name.clone(), hoard_path.clone(), system_path.clone());
+                    (pile_name.clone(), hoard_path, system_path);
                 let unmodified = pile.unmodified.keys().cloned().map(move |rel_path| {
                     ItemOperation::Nothing(HoardItem::new(
                         u_pile_name.clone(),
                         u_hoard_path.clone(),
                         u_system_path.clone(),
-                        rel_path
+                        rel_path,
                     ))
                 });
 
@@ -315,7 +315,8 @@ impl Hoard {
                 "mismatched hoard type and pile name option: hoard ({:?}), pile_name: {:?}",
                 hoard, pile_name
             ),
-        }.unwrap_or_default()
+        }
+        .unwrap_or_default()
     }
 
     fn new(

--- a/src/checkers/history/operation/v2.rs
+++ b/src/checkers/history/operation/v2.rs
@@ -231,7 +231,7 @@ impl OperationImpl for OperationV2 {
                 });
 
                 let (d_pile_name, d_hoard_path, d_system_path) =
-                    (pile_name, hoard_path, system_path);
+                    (pile_name.clone(), hoard_path.clone(), system_path.clone());
                 let deleted = pile.deleted.iter().cloned().map(move |rel_path| {
                     ItemOperation::Delete(HoardItem::new(
                         d_pile_name.clone(),
@@ -241,7 +241,18 @@ impl OperationImpl for OperationV2 {
                     ))
                 });
 
-                Some(created.chain(modified).chain(deleted))
+                let (u_pile_name, u_hoard_path, u_system_path) =
+                    (pile_name.clone(), hoard_path.clone(), system_path.clone());
+                let unmodified = pile.unmodified.keys().cloned().map(move |rel_path| {
+                    ItemOperation::Nothing(HoardItem::new(
+                        u_pile_name.clone(),
+                        u_hoard_path.clone(),
+                        u_system_path.clone(),
+                        rel_path
+                    ))
+                });
+
+                Some(created.chain(modified).chain(deleted).chain(unmodified))
             })
             .flatten();
         Ok(Box::new(iter))
@@ -304,7 +315,7 @@ impl Hoard {
                 "mismatched hoard type and pile name option: hoard ({:?}), pile_name: {:?}",
                 hoard, pile_name
             ),
-        }
+        }.unwrap_or_default()
     }
 
     fn new(

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -175,7 +175,6 @@ mod tests {
         AsymmetricEncryption, Config as PileConfig, Encryption, SymmetricEncryption,
     };
 
-
     mod process {
         use super::*;
         use crate::hoard::Pile as RealPile;
@@ -251,7 +250,7 @@ mod tests {
                     encryption: Some(Encryption::Asymmetric(AsymmetricEncryption {
                         public_key: "public key".to_string(),
                     })),
-                    .. PileConfig::default()
+                    ..PileConfig::default()
                 }),
                 items: btreemap! {
                     "bar_env|foo_env".parse().unwrap() => "/some/path".into()
@@ -335,7 +334,7 @@ mod tests {
                     encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
                         "correcthorsebatterystaple".into(),
                     ))),
-                    .. PileConfig::default()
+                    ..PileConfig::default()
                 }),
                 items: btreemap! {
                     "item1".parse().unwrap() => Pile {
@@ -421,7 +420,7 @@ mod tests {
                     glob::Pattern::new("**/valid*").unwrap(),
                     glob::Pattern::new("*/also_valid/**").unwrap(),
                 ],
-                .. PileConfig::default()
+                ..PileConfig::default()
             };
 
             assert_tokens::<PileConfig>(

--- a/src/config/builder/hoard.rs
+++ b/src/config/builder/hoard.rs
@@ -175,86 +175,6 @@ mod tests {
         AsymmetricEncryption, Config as PileConfig, Encryption, SymmetricEncryption,
     };
 
-    mod config {
-        use super::*;
-        use crate::checksum::ChecksumType;
-
-        #[test]
-        fn test_layer_configs_both_none() {
-            let mut specific = None;
-            let general = None;
-            PileConfig::layer_options(&mut specific, general);
-            assert!(specific.is_none());
-        }
-
-        #[test]
-        fn test_layer_specific_some_general_none() {
-            let mut specific = Some(PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
-                    "password".into(),
-                ))),
-                ignore: vec![glob::Pattern::new("ignore me").unwrap()],
-            });
-            let old_specific = specific.clone();
-            let general = None;
-            PileConfig::layer_options(&mut specific, general);
-            assert_eq!(specific, old_specific);
-        }
-
-        #[test]
-        fn test_layer_specific_none_general_some() {
-            let mut specific = None;
-            let general = Some(PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
-                    "password".into(),
-                ))),
-                ignore: vec![glob::Pattern::new("ignore me").unwrap()],
-            });
-            PileConfig::layer_options(&mut specific, general.as_ref());
-            assert_eq!(specific, general);
-        }
-
-        #[test]
-        fn test_layer_configs_both_some() {
-            let mut specific = Some(PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
-                    "password".into(),
-                ))),
-                ignore: vec![
-                    glob::Pattern::new("ignore me").unwrap(),
-                    glob::Pattern::new("duplicate").unwrap(),
-                ],
-            });
-            let old_specific = specific.clone();
-            let general = Some(PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: Some(Encryption::Asymmetric(AsymmetricEncryption {
-                    public_key: "somekey".into(),
-                })),
-                ignore: vec![
-                    glob::Pattern::new("me too").unwrap(),
-                    glob::Pattern::new("duplicate").unwrap(),
-                ],
-            });
-            PileConfig::layer_options(&mut specific, general.as_ref());
-            assert!(specific.is_some());
-            assert_eq!(
-                specific.as_ref().unwrap().encryption,
-                old_specific.unwrap().encryption
-            );
-            assert_eq!(
-                specific.unwrap().ignore,
-                vec![
-                    glob::Pattern::new("duplicate").unwrap(),
-                    glob::Pattern::new("ignore me").unwrap(),
-                    glob::Pattern::new("me too").unwrap(),
-                ]
-            );
-        }
-    }
 
     mod process {
         use super::*;
@@ -299,7 +219,6 @@ mod tests {
 
     mod serde {
         use super::*;
-        use crate::checksum::ChecksumType;
         use maplit::btreemap;
         use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
@@ -329,11 +248,10 @@ mod tests {
         fn single_entry_with_config() {
             let hoard = Hoard::Single(Pile {
                 config: Some(PileConfig {
-                    checksum_type: ChecksumType::default(),
                     encryption: Some(Encryption::Asymmetric(AsymmetricEncryption {
                         public_key: "public key".to_string(),
                     })),
-                    ignore: Vec::new(),
+                    .. PileConfig::default()
                 }),
                 items: btreemap! {
                     "bar_env|foo_env".parse().unwrap() => "/some/path".into()
@@ -348,14 +266,10 @@ mod tests {
                     Token::Some,
                     Token::Struct {
                         name: "Config",
-                        len: 3,
+                        len: 5,
                     },
                     Token::Str("hash_algorithm"),
-                    Token::Enum {
-                        name: "ChecksumType",
-                    },
-                    Token::Str("sha256"),
-                    Token::Unit,
+                    Token::None,
                     Token::Str("encrypt"),
                     Token::Some,
                     Token::Struct {
@@ -370,6 +284,10 @@ mod tests {
                     Token::Str("ignore"),
                     Token::Seq { len: Some(0) },
                     Token::SeqEnd,
+                    Token::Str("file_permissions"),
+                    Token::None,
+                    Token::Str("folder_permissions"),
+                    Token::None,
                     Token::StructEnd,
                     Token::Str("bar_env|foo_env"),
                     Token::Str("/some/path"),
@@ -414,11 +332,10 @@ mod tests {
         fn multiple_entry_with_config() {
             let hoard = Hoard::Multiple(MultipleEntries {
                 config: Some(PileConfig {
-                    checksum_type: ChecksumType::default(),
                     encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
                         "correcthorsebatterystaple".into(),
                     ))),
-                    ignore: Vec::new(),
+                    .. PileConfig::default()
                 }),
                 items: btreemap! {
                     "item1".parse().unwrap() => Pile {
@@ -438,14 +355,10 @@ mod tests {
                     Token::Some,
                     Token::Struct {
                         name: "Config",
-                        len: 3,
+                        len: 5,
                     },
                     Token::Str("hash_algorithm"),
-                    Token::Enum {
-                        name: "ChecksumType",
-                    },
-                    Token::Str("sha256"),
-                    Token::Unit,
+                    Token::None,
                     Token::Str("encrypt"),
                     Token::Some,
                     Token::Map { len: Some(2) },
@@ -457,6 +370,10 @@ mod tests {
                     Token::Str("ignore"),
                     Token::Seq { len: Some(0) },
                     Token::SeqEnd,
+                    Token::Str("file_permissions"),
+                    Token::None,
+                    Token::Str("folder_permissions"),
+                    Token::None,
                     Token::StructEnd,
                     Token::Str("item1"),
                     Token::Map { len: None },
@@ -476,13 +393,15 @@ mod tests {
                 &[
                     Token::Struct {
                         name: "Config",
-                        len: 3,
+                        len: 5,
                     },
                     Token::Str("hash_algorithm"),
-                    Token::Enum { name: "ChecksumType" },
-                    Token::Str("sha256"),
-                    Token::Unit,
+                    Token::None,
                     Token::Str("encrypt"),
+                    Token::None,
+                    Token::Str("file_permissions"),
+                    Token::None,
+                    Token::Str("folder_permissions"),
                     Token::None,
                     Token::Str("ignore"),
                     Token::Seq { len: Some(2) },
@@ -498,12 +417,11 @@ mod tests {
         #[test]
         fn test_valid_globs() {
             let config = PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: None,
                 ignore: vec![
                     glob::Pattern::new("**/valid*").unwrap(),
                     glob::Pattern::new("*/also_valid/**").unwrap(),
                 ],
+                .. PileConfig::default()
             };
 
             assert_tokens::<PileConfig>(
@@ -511,14 +429,10 @@ mod tests {
                 &[
                     Token::Struct {
                         name: "Config",
-                        len: 3,
+                        len: 5,
                     },
                     Token::Str("hash_algorithm"),
-                    Token::Enum {
-                        name: "ChecksumType",
-                    },
-                    Token::Str("sha256"),
-                    Token::Unit,
+                    Token::None,
                     Token::Str("encrypt"),
                     Token::None,
                     Token::Str("ignore"),
@@ -526,6 +440,10 @@ mod tests {
                     Token::Str("**/valid*"),
                     Token::Str("*/also_valid/**"),
                     Token::SeqEnd,
+                    Token::Str("file_permissions"),
+                    Token::None,
+                    Token::Str("folder_permissions"),
+                    Token::None,
                     Token::StructEnd,
                 ],
             );

--- a/src/filters/ignore.rs
+++ b/src/filters/ignore.rs
@@ -59,14 +59,14 @@ mod tests {
         let filter = {
             let config = PileConfig {
                 ignore: vec![Pattern::new("testing/**").unwrap()],
-                .. PileConfig::default()
+                ..PileConfig::default()
             };
             IgnoreFilter::new(&config).expect("filter should be valid")
         };
         let other = {
             let config = PileConfig {
                 ignore: vec![Pattern::new("test/**").unwrap()],
-                .. PileConfig::default()
+                ..PileConfig::default()
             };
             IgnoreFilter::new(&config).expect("filter should be valid")
         };

--- a/src/filters/ignore.rs
+++ b/src/filters/ignore.rs
@@ -53,23 +53,20 @@ impl Filter for IgnoreFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::checksum::ChecksumType;
 
     #[test]
     fn test_filter_derives() {
         let filter = {
             let config = PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: None,
                 ignore: vec![Pattern::new("testing/**").unwrap()],
+                .. PileConfig::default()
             };
             IgnoreFilter::new(&config).expect("filter should be valid")
         };
         let other = {
             let config = PileConfig {
-                checksum_type: ChecksumType::default(),
-                encryption: None,
                 ignore: vec![Pattern::new("test/**").unwrap()],
+                .. PileConfig::default()
             };
             IgnoreFilter::new(&config).expect("filter should be valid")
         };

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -51,14 +51,12 @@ impl Filter for Filters {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::checksum::ChecksumType;
 
     #[test]
     fn test_filters_derives() {
         let config = PileConfig {
-            checksum_type: ChecksumType::default(),
-            encryption: None,
             ignore: vec![glob::Pattern::new("valid/**").unwrap()],
+            .. PileConfig::default()
         };
         let filters = Filters::new(&config).expect("config should be valid");
         assert!(format!("{:?}", filters).contains("Filters"));

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -56,7 +56,7 @@ mod tests {
     fn test_filters_derives() {
         let config = PileConfig {
             ignore: vec![glob::Pattern::new("valid/**").unwrap()],
-            .. PileConfig::default()
+            ..PileConfig::default()
         };
         let filters = Filters::new(&config).expect("config should be valid");
         assert!(format!("{:?}", filters).contains("Filters"));

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -128,6 +128,7 @@ impl Hoard {
     }
 
     /// Returns the pile with the given [`PileName`], if exists.
+    #[must_use]
     pub fn get_pile(&self, name: &PileName) -> Option<&Pile> {
         match (name.as_ref(), self) {
             (None, Self::Anonymous(pile)) => Some(pile),

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -126,4 +126,13 @@ impl Hoard {
             )),
         }
     }
+
+    /// Returns the pile with the given [`PileName`], if exists.
+    pub fn get_pile(&self, name: &PileName) -> Option<&Pile> {
+        match (name.as_ref(), self) {
+            (None, Self::Anonymous(pile)) => Some(pile),
+            (Some(name), Self::Named(map)) => map.piles.get(name),
+            _ => None,
+        }
+    }
 }

--- a/src/hoard/pile_config.rs
+++ b/src/hoard/pile_config.rs
@@ -1,3 +1,7 @@
+use std::{fs, io};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use crate::checksum::ChecksumType;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -28,6 +32,97 @@ pub enum Encryption {
     Symmetric(SymmetricEncryption),
     /// Asymmetric encryption.
     Asymmetric(AsymmetricEncryption),
+}
+
+
+
+/// Configurable permissions for files and folders.
+///
+/// Can be declared as a unix `chmod(1)` style mode or as a set of boolean flags.
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum Permissions {
+    Mode(u32),
+    #[serde(rename = "permissions")]
+    Manual {
+        is_executable: bool,
+        is_readable: bool,
+        is_writable: bool,
+        others_can_read: bool,
+        others_can_write: bool,
+        #[serde(alias = "others_can_list")]
+        others_can_execute: bool,
+    }
+}
+
+impl Permissions {
+    const OWNER_READ: u32 = 0o400;
+    const OWNER_WRITE: u32 = 0o200;
+    const OWNER_EXE: u32 = 0o100;
+    const OTHER_READ: u32 = 0o044;
+    const OTHER_WRITE: u32 = 0o022;
+    const OTHER_EXE: u32 = 0o011;
+    const EMPTY: u32 = 0;
+
+    /// The default permissions for files.
+    ///
+    /// Currently, this is owner-only read/write permissions.
+    pub fn file_default() -> Self {
+        Self::Mode(Self::OWNER_READ | Self::OWNER_WRITE)
+    }
+
+    /// The default permissions for directories.
+    ///
+    /// Currently, this is owner-only read/write/execute permissions
+    /// (execute is necessary on unix-y systems to list the contents).
+    pub fn folder_default() -> Self {
+        Self::Mode(Self::OWNER_READ | Self::OWNER_WRITE | Self::OWNER_EXE)
+    }
+
+    #[cfg(unix)]
+    pub fn as_mode(self) -> u32 {
+        match self {
+            Self::Mode(mode) => mode,
+            Self::Manual { is_executable, is_readable, is_writable, others_can_read, others_can_write, others_can_execute } => {
+                let owner_exe = if is_executable { Self::OWNER_EXE } else { Self::EMPTY };
+                let owner_write = if is_writable { Self::OWNER_WRITE } else { Self::EMPTY };
+                let owner_read = if is_readable { Self::OWNER_READ } else { Self::EMPTY };
+
+                let other_exe = if others_can_execute { Self::OTHER_EXE } else { Self::EMPTY };
+                let other_write = if others_can_write { Self::OTHER_WRITE } else { Self::EMPTY };
+                let other_read = if others_can_read { Self::OTHER_READ } else { Self::EMPTY };
+
+                owner_read | owner_write | owner_exe | other_read | other_write | other_exe
+            }
+        }
+    }
+
+    pub fn is_readonly(self) -> bool {
+        match self {
+            Self::Mode(mode) => mode & Self::OTHER_WRITE == 0,
+            Self::Manual { is_writable, .. } => !is_writable,
+        }
+    }
+
+    pub fn set_permissions(self, mut perms: fs::Permissions) -> fs::Permissions {
+        #[cfg(unix)]
+        perms.set_mode(self.as_mode());
+        #[cfg(not(unix))]
+        perms.set_readonly(self.is_readonly());
+        perms
+    }
+
+    pub fn set_on_path(self, path: &Path) -> io::Result<()> {
+        let perms = fs::metadata(path).map_err(|err| {
+            tracing::error!("failed to read current permissions for {}: {}", path.display(), err);
+            err
+        })?.permissions();
+        let perms = self.set_permissions(perms);
+        fs::set_permissions(path, perms).map_err(|err| {
+            tracing::error!("failed to set permissions on {}: {}", path.display(), err);
+            err
+        })
+    }
 }
 
 #[allow(single_use_lifetimes)]
@@ -62,7 +157,7 @@ where
 pub struct Config {
     /// The [`ChecksumType`] to use when hashing files.
     #[serde(default, rename = "hash_algorithm")]
-    pub checksum_type: ChecksumType,
+    pub checksum_type: Option<ChecksumType>,
     /// The [`Encryption`] configuration for a pile.
     #[serde(default, rename = "encrypt")]
     pub encryption: Option<Encryption>,
@@ -73,6 +168,16 @@ pub struct Config {
         serialize_with = "serialize_glob"
     )]
     pub ignore: Vec<glob::Pattern>,
+    /// The [`Permissions`] to set on restored files.
+    ///
+    /// See [`Permissions::file_default`] for the default value.
+    #[serde(default)]
+    pub file_permissions: Option<Permissions>,
+    /// The [`Permissions`] to set on restored folders.
+    ///
+    /// See [`Permissions::folder_default`] for the default value.
+    #[serde(default)]
+    pub folder_permissions: Option<Permissions>,
 }
 
 impl Config {
@@ -83,6 +188,11 @@ impl Config {
         if self.encryption.is_none() {
             self.encryption = other.encryption.clone();
         }
+
+        self.checksum_type = self.checksum_type.or(other.checksum_type);
+
+        self.file_permissions = self.file_permissions.or(other.file_permissions);
+        self.folder_permissions = self.folder_permissions.or(other.folder_permissions);
 
         // Merge ignore lists.
         self.ignore.extend(other.ignore.clone());
@@ -98,6 +208,224 @@ impl Config {
                     specific.replace(general.clone());
                 }
                 Some(this_config) => this_config.layer(general),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checksum::ChecksumType;
+    use crate::hoard::pile_config::Permissions;
+
+    #[test]
+    fn test_layer_configs_both_none() {
+        let mut specific = None;
+        let general = None;
+        Config::layer_options(&mut specific, general);
+        assert!(specific.is_none());
+    }
+
+    #[test]
+    fn test_layer_specific_some_general_none() {
+        let mut specific = Some(Config {
+            checksum_type: Some(ChecksumType::default()),
+            encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
+                "password".into(),
+            ))),
+            ignore: vec![glob::Pattern::new("ignore me").unwrap()],
+            file_permissions: Some(Permissions::Mode(0o666)),
+            folder_permissions: Some(Permissions::Mode(0o777)),
+        });
+        let old_specific = specific.clone();
+        let general = None;
+        Config::layer_options(&mut specific, general);
+        assert_eq!(specific, old_specific);
+    }
+
+    #[test]
+    fn test_layer_specific_none_general_some() {
+        let mut specific = None;
+        let general = Some(Config {
+            checksum_type: Some(ChecksumType::default()),
+            encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
+                "password".into(),
+            ))),
+            ignore: vec![glob::Pattern::new("ignore me").unwrap()],
+            file_permissions: Some(Permissions::Mode(0o666)),
+            folder_permissions: Some(Permissions::Mode(0o777)),
+        });
+        Config::layer_options(&mut specific, general.as_ref());
+        assert_eq!(specific, general);
+    }
+
+    #[test]
+    fn test_layer_configs_both_some() {
+        let mut specific = Some(Config {
+            checksum_type: Some(ChecksumType::default()),
+            encryption: Some(Encryption::Symmetric(SymmetricEncryption::Password(
+                "password".into(),
+            ))),
+            ignore: vec![
+                glob::Pattern::new("ignore me").unwrap(),
+                glob::Pattern::new("duplicate").unwrap(),
+            ],
+            file_permissions: Some(Permissions::Mode(0o644)),
+            folder_permissions: Some(Permissions::Mode(0o777)),
+        });
+        let old_specific = specific.clone();
+        let general = Some(Config {
+            checksum_type: Some(ChecksumType::default()),
+            encryption: Some(Encryption::Asymmetric(AsymmetricEncryption {
+                public_key: "somekey".into(),
+            })),
+            ignore: vec![
+                glob::Pattern::new("me too").unwrap(),
+                glob::Pattern::new("duplicate").unwrap(),
+            ],
+            file_permissions: Some(Permissions::Mode(0o666)),
+            folder_permissions: Some(Permissions::Mode(0o755)),
+        });
+        Config::layer_options(&mut specific, general.as_ref());
+        assert!(specific.is_some());
+        assert_eq!(
+            specific.as_ref().unwrap().encryption,
+            old_specific.unwrap().encryption
+        );
+        assert_eq!(
+            specific.as_ref().unwrap().ignore,
+            vec![
+                glob::Pattern::new("duplicate").unwrap(),
+                glob::Pattern::new("ignore me").unwrap(),
+                glob::Pattern::new("me too").unwrap(),
+            ]
+        );
+        assert_eq!(specific.as_ref().unwrap().file_permissions.unwrap().as_mode(), 0o644);
+        assert_eq!(specific.as_ref().unwrap().folder_permissions.unwrap().as_mode(), 0o777);
+    }
+
+    mod permissions {
+        use super::*;
+
+        #[allow(clippy::too_many_lines)]
+        #[test]
+        fn test_as_mode() {
+            let perms = [
+                (Permissions::Mode(0o000), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: false,
+                    is_writable: false,
+                    others_can_read: false,
+                    others_can_write: false,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o011), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: false,
+                    is_writable: false,
+                    others_can_read: false,
+                    others_can_write: false,
+                    others_can_execute: true
+                }),
+                (Permissions::Mode(0o100), Permissions::Manual {
+                    is_executable: true,
+                    is_readable: false,
+                    is_writable: false,
+                    others_can_read: false,
+                    others_can_write: false,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o111), Permissions::Manual {
+                    is_executable: true,
+                    is_readable: false,
+                    is_writable: false,
+                    others_can_read: false,
+                    others_can_write: false,
+                    others_can_execute: true
+                }),
+                (Permissions::Mode(0o022), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: false,
+                    is_writable: false,
+                    others_can_read: false,
+                    others_can_write: true,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o200), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: false,
+                    is_writable: true,
+                    others_can_read: false,
+                    others_can_write: false,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o222), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: false,
+                    is_writable: true,
+                    others_can_read: false,
+                    others_can_write: true,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o044), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: false,
+                    is_writable: false,
+                    others_can_read: true,
+                    others_can_write: false,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o400), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: true,
+                    is_writable: false,
+                    others_can_read: false,
+                    others_can_write: false,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o444), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: true,
+                    is_writable: false,
+                    others_can_read: true,
+                    others_can_write: false,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o555), Permissions::Manual {
+                    is_executable: true,
+                    is_readable: true,
+                    is_writable: false,
+                    others_can_read: true,
+                    others_can_write: false,
+                    others_can_execute: true
+                }),
+                (Permissions::Mode(0o666), Permissions::Manual {
+                    is_executable: false,
+                    is_readable: true,
+                    is_writable: true,
+                    others_can_read: true,
+                    others_can_write: true,
+                    others_can_execute: false
+                }),
+                (Permissions::Mode(0o777), Permissions::Manual {
+                    is_executable: true,
+                    is_readable: true,
+                    is_writable: true,
+                    others_can_read: true,
+                    others_can_write: true,
+                    others_can_execute: true
+                }),
+            ];
+
+            for (mode, manual) in perms {
+                if let Permissions::Mode(m) = mode {
+                    assert_eq!(mode.as_mode(), m);
+                } else {
+                    unreachable!();
+                }
+
+                assert_eq!(mode.as_mode(), manual.as_mode());
             }
         }
     }

--- a/src/hoard/pile_config.rs
+++ b/src/hoard/pile_config.rs
@@ -127,7 +127,7 @@ impl Permissions {
 
     pub fn is_readonly(self) -> bool {
         match self {
-            Self::Mode(mode) => mode & Self::OTHER_WRITE == 0,
+            Self::Mode(mode) => (mode & Self::OWNER_WRITE) == 0,
             Self::Manual { is_writable, .. } => !is_writable,
         }
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -339,11 +339,16 @@ impl RelativePath {
     }
 
     /// Returns the parent [`RelativePath`] to this one.
-    /// 
+    ///
     /// If this `RelativePath` has one or fewer components to it, an empty `RelativePath` is returned.
     #[must_use]
     pub fn parent(&self) -> RelativePath {
-        RelativePath(self.0.as_deref().and_then(Path::parent).map(Path::to_path_buf))
+        RelativePath(
+            self.0
+                .as_deref()
+                .and_then(Path::parent)
+                .map(Path::to_path_buf),
+        )
     }
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -337,6 +337,14 @@ impl RelativePath {
     pub fn none() -> Self {
         Self(None)
     }
+
+    /// Returns the parent [`RelativePath`] to this one.
+    /// 
+    /// If this `RelativePath` has one or fewer components to it, an empty `RelativePath` is returned.
+    #[must_use]
+    pub fn parent(&self) -> RelativePath {
+        RelativePath(self.0.as_deref().and_then(Path::parent).map(Path::to_path_buf))
+    }
 }
 
 #[cfg(test)]

--- a/tests/restore_permissions.rs
+++ b/tests/restore_permissions.rs
@@ -1,0 +1,265 @@
+mod common;
+
+use std::fs;
+use std::fs::Permissions;
+use common::tester::Tester;
+use hoard::command::Command;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+const CONFIG: &str = r#"
+exclusivity = [
+    ["first", "second"],
+    ["unix", "windows"]
+]
+
+[envs]
+[envs.windows]
+    os = ["windows"]
+[envs.unix]
+    os = ["linux", "macos"]
+
+
+[hoards]
+[hoards.anon_txt]
+    "unix"    = "${HOME}/anon.txt"
+    "windows" = "${HOARD_TMP}/anon.txt"
+[hoards.anon_txt.config]
+    file_permissions = 0o444
+
+[hoards.anon_bin]
+    "unix"    = "${HOME}/anon.bin"
+    "windows" = "${HOARD_TMP}/anon.bin"
+[hoards.anon_bin.config]
+    file_permissions = 0o755
+
+[hoards.readonly_dir]
+    "unix"    = "${HOME}/readonly"
+    "windows" = "${HOARD_TMP}/readonly"
+[hoards.readonly_dir.config]
+    folder_permissions = 0o555
+
+[hoards.anon_dir]
+    "unix"    = "${HOME}/testdir"
+    "windows" = "${HOARD_TMP}/testdir"
+[hoards.anon_dir.config.file_permissions]
+    is_readable = true
+    is_writable = false
+    is_executable = false
+    others_can_read = true
+    others_can_write = false
+    others_can_execute = true
+[hoards.anon_dir.config.folder_permissions]
+    is_readable = true
+    is_writable = true
+    is_executable = true
+    others_can_read = true
+    others_can_write = false
+    others_can_execute = true
+
+[hoards.default_dir]
+    config = { ignore = ["**/ignore"] }
+    "unix"    = "${HOME}/defaultdir"
+    "windows" = "${HOARD_TMP}/defaultdir"
+"#;
+
+#[test]
+fn test_default_permissions() {
+    let tester = Tester::with_log_level(CONFIG, tracing::Level::DEBUG);
+    let root = tester.home_dir().join("defaultdir");
+    let file = root.join("file");
+    let ignored = root.join("subdir").join("ignore");
+    let hoards = vec!["default_dir".parse().unwrap()];
+
+    fs::create_dir_all(ignored.parent().unwrap()).unwrap();
+    fs::write(&file, "test content").unwrap();
+    fs::write(&ignored, "ignore me!").unwrap();
+    tester.expect_command(Command::Backup { hoards: hoards.clone() });
+
+    #[cfg(unix)]
+    {
+        // Set permissions to something other than the expected value.
+        fs::set_permissions(tester.home_dir(), Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&root, Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&ignored.parent().unwrap(), Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&file, Permissions::from_mode(0o644)).unwrap();
+        fs::set_permissions(&ignored, Permissions::from_mode(0o644)).unwrap();
+    }
+
+    tester.expect_command(Command::Restore { hoards: hoards.clone() });
+
+    let file_perms = fs::metadata(&file).unwrap().permissions();
+    let dir_perms = fs::metadata(&root).unwrap().permissions();
+
+    assert_eq!((false, false), (file_perms.readonly(), dir_perms.readonly()));
+
+    #[cfg(unix)]
+    {
+        let home_perms = fs::metadata(tester.home_dir()).unwrap().permissions();
+        let ignored_dir_perms = fs::metadata(ignored.parent().unwrap()).unwrap().permissions();
+        let ignored_perms = fs::metadata(ignored).unwrap().permissions();
+        assert_eq!(0o100600, file_perms.mode());
+        assert_eq!(0o040700, dir_perms.mode());
+        assert_eq!(0o040755, home_perms.mode(), "permissions should not be set on the parent of pile root");
+        assert_eq!(0o040755, ignored_dir_perms.mode(), "permissions should not be set on the parent of ignored file");
+        assert_eq!(0o100644, ignored_perms.mode(), "permissions should not be set on ignored file");
+    }
+}
+
+#[test]
+fn test_anon_txt_configured_perms() {
+    let tester = Tester::new(CONFIG);
+    let file = tester.home_dir().join("anon.txt");
+    let hoards = vec!["anon_txt".parse().unwrap()];
+
+    fs::write(&file, "content").unwrap();
+
+    tester.expect_command(Command::Backup { hoards: hoards.clone() });
+
+    fs::remove_file(&file).unwrap();
+
+    tester.expect_command(Command::Restore { hoards: hoards.clone() });
+
+    assert!(file.exists());
+    let perms = fs::metadata(file).unwrap().permissions();
+
+    #[cfg(unix)]
+    assert_eq!(0o100444, perms.mode());
+    assert_eq!(true, perms.readonly());
+}
+
+#[test]
+fn test_anon_bin_configured_perms() {
+    let tester = Tester::new(CONFIG);
+    let file = tester.home_dir().join("anon.bin");
+    let hoards = vec!["anon_bin".parse().unwrap()];
+
+    fs::write(&file, [0xFF, 0xFF, 0xFF, 0xDE]).unwrap();
+
+    tester.expect_command(Command::Backup { hoards: hoards.clone() });
+
+    tester.expect_command(Command::Restore { hoards: hoards.clone() });
+
+    let perms = fs::metadata(file).unwrap().permissions();
+
+    #[cfg(unix)]
+    assert_eq!(0o100755, perms.mode());
+    assert_eq!(false, perms.readonly());
+}
+
+#[test]
+fn test_anon_dir_configured_perms() {
+    let tester = Tester::with_log_level(CONFIG, tracing::Level::DEBUG);
+    let root = tester.home_dir().join("testdir");
+    let file1 = root.join("file");
+    let sub_dir = root.join("subdir");
+    let file2 = sub_dir.join("file");
+    let hoards = vec!["anon_dir".parse().unwrap()];
+
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(&file1, "content 1").unwrap();
+    fs::write(&file2, "content 2").unwrap();
+
+    tester.expect_command(Command::Backup { hoards: hoards.clone() });
+
+    fs::remove_dir_all(&sub_dir).unwrap();
+    fs::remove_file(&file1).unwrap();
+
+    tester.expect_command(Command::Restore { hoards: hoards.clone() });
+    println!("{}", tester.output());
+
+    assert!(root.exists());
+    assert!(file1.exists());
+    assert!(sub_dir.exists());
+    assert!(file2.exists());
+
+    let root_perms = fs::metadata(root).unwrap().permissions();
+    let file1_perms = fs::metadata(file1).unwrap().permissions();
+    let sub_dir_perms = fs::metadata(sub_dir).unwrap().permissions();
+    let file2_perms = fs::metadata(file2).unwrap().permissions();
+
+    assert_eq!(root_perms, sub_dir_perms);
+    assert_eq!(file1_perms, file2_perms);
+    #[cfg(unix)]
+    assert_eq!((0o100455, 0o040755), (file1_perms.mode(), root_perms.mode()));
+    assert_eq!((true, false), (file1_perms.readonly(), root_perms.readonly()));
+}
+
+#[test]
+fn test_readonly_dir() {
+    let tester = Tester::new(CONFIG);
+    let root = tester.home_dir().join("readonly");
+    let sub_dir = root.join("subdir");
+    let file = sub_dir.join("file");
+    let hoards = vec!["readonly_dir".parse().unwrap()];
+
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(&file, "content").unwrap();
+
+    tester.expect_command(Command::Backup { hoards: hoards.clone() });
+    
+    for path in [&file, &sub_dir, &root] {
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_readonly(false);
+        fs::set_permissions(&path, perms.clone()).unwrap();
+        if path.is_file() {
+            fs::remove_file(&path).unwrap();
+        } else if path.is_dir() {
+            perms.set_readonly(true);
+            fs::set_permissions(&path, perms).unwrap();
+        }
+    }
+
+    tester.expect_command(Command::Restore { hoards: hoards.clone() });
+
+    assert!(root.exists());
+    assert!(sub_dir.exists());
+    assert!(file.exists());
+
+    let root_perms = fs::metadata(root).unwrap().permissions();
+    let sub_dir_perms = fs::metadata(sub_dir).unwrap().permissions();
+    let file_perms = fs::metadata(file).unwrap().permissions();
+
+    assert_eq!(root_perms, sub_dir_perms);
+    #[cfg(unix)]
+    assert_eq!((0o100600, 0o040555), (file_perms.mode(), root_perms.mode()));
+    assert_eq!((false, true), (file_perms.readonly(), root_perms.readonly()));
+}
+
+#[test]
+fn test_hoard_file_permissions() {
+    let tester = Tester::with_log_level(CONFIG, tracing::Level::DEBUG);
+    let root = tester.home_dir().join("testdir");
+    let file1 = root.join("file");
+    let sub_dir = root.join("subdir");
+    let file2 = sub_dir.join("file");
+    let hoards = vec!["anon_dir".parse().unwrap()];
+
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(&file1, "content 1").unwrap();
+    fs::write(&file2, "content 2").unwrap();
+
+    tester.expect_command(Command::Backup { hoards: hoards.clone() });
+
+    let hoard_root = tester.data_dir().join("hoards").join("anon_dir");
+    let hoard_file1 = hoard_root.join("file");
+    let hoard_subdir = hoard_root.join("subdir");
+    let hoard_file2 = hoard_subdir.join("file");
+
+    assert!(hoard_root.exists());
+    assert!(hoard_file1.exists());
+    assert!(hoard_subdir.exists());
+    assert!(hoard_file2.exists());
+
+    let root_perms = fs::metadata(hoard_root).unwrap().permissions();
+    let file1_perms = fs::metadata(hoard_file1).unwrap().permissions();
+    let sub_dir_perms = fs::metadata(hoard_subdir).unwrap().permissions();
+    let file2_perms = fs::metadata(hoard_file2).unwrap().permissions();
+
+    assert_eq!(root_perms, sub_dir_perms);
+    assert_eq!(file1_perms, file2_perms);
+    #[cfg(unix)]
+    assert_eq!((0o100600, 0o040700), (file1_perms.mode(), root_perms.mode()));
+    assert_eq!((false, false), (file1_perms.readonly(), root_perms.readonly()));
+}


### PR DESCRIPTION
This adds two methods of specifying file permissions per-pile-config:

- Unix-style mode
- Boolean flags

The following behavior is performed now on backup/restore:

- Set destination parent directories permissions to 0700
  - Also creating directories as needed
  - This applies only to directories under the pile prefix
- Copy files as necessary
- After copying a file, set the new file's permissions to:
  - 0600 on backup
  - The configured mode on restore
- Also set parent directory permissions as with files, but defaulting to
  0700

As usual, the default file mode/permissions can be overridden using the
top-level pile configuration section of the configuration file.