### PR TITLE
fix: fix operation version upgrades

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,6 +65,26 @@ jobs:
           command: fmt
           args: -- --check
 
+  operation_upgrade:
+    name: Operation Version Upgrade
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run test script
+        run: bash ./operation_upgrade_test.sh
+
   check-stable:
     name: Check Commit
     runs-on: ${{ matrix.os }}

--- a/operation_upgrade_test.sh
+++ b/operation_upgrade_test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+die() {
+    echo "$@" 1>&2
+    exit 1
+}
+
+if [ $(uname -s) != "Linux" ] || [ $(uname -m) != "x86_64" ]; then
+    die "This test is intended to run on x86_64 Linux"
+fi
+
+export TEST_ROOT="/tmp/hoard"
+export ARCHIVE_ROOT="${TEST_ROOT}/archives"
+export BIN_ROOT="${TEST_ROOT}/bin"
+export XDG_CONFIG_HOME="${TEST_ROOT}/config"
+export XDG_DATA_HOME="${TEST_ROOT}/data"
+export HOARD_CONFIG_DIR="${XDG_CONFIG_HOME}/hoard"
+export HOARD_DATA_DIR="${XDG_DATA_HOME}/hoard"
+export HOARD_FILES="${TEST_ROOT}/files"
+export CONFIG_FILE="${HOARD_CONFIG_DIR}/config.toml"
+export HOARD_LOG="trace"
+
+call_hoard() {
+    version="$1"
+    shift
+    args=(--config-file "${CONFIG_FILE}" "${@}")
+    if [ "${version}" = "cargo" ]; then
+        cargo run -- "${args[@]}"
+    else
+        "${BIN_ROOT}/hoard-${version}" "${args[@]}"
+    fi
+}
+
+download_hoard() {
+    version="$1"
+    mkdir -p "${BIN_ROOT}"
+    mkdir -p "${ARCHIVE_ROOT}"
+    curl -L -o "${ARCHIVE_ROOT}/hoard-${version}.tar.gz" "https://github.com/Shadow53/hoard/releases/download/${version}/hoard-x86_64-unknown-linux-gnu.tar.gz"
+    tar -xzvf "${ARCHIVE_ROOT}/hoard-${version}.tar.gz" -C "${BIN_ROOT}" hoard
+    mv "${BIN_ROOT}/hoard" "${BIN_ROOT}/hoard-${version}"
+    chmod +x "${BIN_ROOT}/hoard-${version}"
+}
+
+reset_file() {
+    mkdir -p "$(dirname "$1")"
+    dd bs=1M count=1 if=/dev/urandom of="$1"
+}
+
+reset_files() {
+    reset_file "${HOARD_FILES}/anon_file"
+    reset_file "${HOARD_FILES}/named_file"
+    reset_file "${HOARD_FILES}/anon_dir/some_file"
+    reset_file "${HOARD_FILES}/anon_dir/some_dir/another_file"
+    reset_file "${HOARD_FILES}/named_dir/some_file"
+    reset_file "${HOARD_FILES}/named_dir/some_dir/another_file"
+}
+
+run_hoard_version() {
+    version="$1"
+    reset_files
+    if [ "${version}" != "cargo" ]; then
+        download_hoard "${version}"
+    fi
+
+    if [ "${version}" != "v0.4.0" ]; then
+        if ! call_hoard "${version}" upgrade; then
+            die "upgrade command failed"
+        fi
+    fi
+
+    if ! call_hoard "${version}" backup; then
+        die "backup command failed"
+    fi
+}
+
+rm -rf "${TEST_ROOT}"
+
+mkdir -p "${HOARD_CONFIG_DIR}"
+mkdir -p "${HOARD_DATA_DIR}"
+mkdir -p "${HOARD_FILES}"
+
+tee "${CONFIG_FILE}" << EOF
+[envs.always]
+    env = [{ var = "HOARD_FILES" }]
+
+[hoards.anon_file]
+    "always" = "${HOARD_FILES}/anon_file"
+
+[hoards.anon_dir]
+    "always" = "${HOARD_FILES}/anon_dir"
+
+[hoards.named]
+[hoards.named.file]
+    "always" = "${HOARD_FILES}/named_file"
+[hoards.named.dir]
+    "always" = "${HOARD_FILES}/named_dir"
+EOF
+
+run_hoard_version "v0.4.0"
+read -p "Paused..." unused
+run_hoard_version "cargo"
+
+rm -rf "${TEST_ROOT}"
+
+echo "Success!"

--- a/operation_upgrade_test.sh
+++ b/operation_upgrade_test.sh
@@ -64,7 +64,12 @@ run_hoard_version() {
 
     if [ "${version}" != "v0.4.0" ]; then
         if ! call_hoard "${version}" upgrade; then
-            die "upgrade command failed"
+            die "first upgrade command failed"
+        fi
+
+        # Run again to make sure upgrading from the newest version also works
+        if ! call_hoard "${version}" upgrade; then
+            die "second upgrade command failed"
         fi
     fi
 

--- a/src/checkers/history/last_paths.rs
+++ b/src/checkers/history/last_paths.rs
@@ -163,6 +163,7 @@ pub struct HoardPaths {
 
 /// Internal type for [`HoardPaths`] mapping to anonymous or named piles.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum PilePaths {
     /// A single, anonymous pile's path.
     Anonymous(Option<SystemPath>),

--- a/src/checkers/history/operation/mod.rs
+++ b/src/checkers/history/operation/mod.rs
@@ -4,10 +4,10 @@ use crate::checkers::history::operation::util::TIME_FORMAT;
 use crate::checkers::Checker;
 use crate::hoard::{Direction, Hoard};
 use futures::stream::TryStreamExt;
+use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use serde::de::Error as _;
 use thiserror::Error;
 use time::OffsetDateTime;
 use tokio::{fs, io};
@@ -122,9 +122,7 @@ impl<'de> Deserialize<'de> for OperationVersion {
         D: serde::Deserializer<'de>,
     {
         let content =
-            match <serde::__private::de::Content as Deserialize>::deserialize(
-                deserializer,
-            ) {
+            match <serde::__private::de::Content as Deserialize>::deserialize(deserializer) {
                 Ok(val) => val,
                 Err(err) => {
                     return Err(err);
@@ -133,9 +131,7 @@ impl<'de> Deserialize<'de> for OperationVersion {
 
         match Result::map(
             <OperationV2 as serde::Deserialize>::deserialize(
-                serde::__private::de::ContentRefDeserializer::<D::Error>::new(
-                    &content,
-                ),
+                serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
             ),
             OperationVersion::V2,
         ) {
@@ -147,9 +143,7 @@ impl<'de> Deserialize<'de> for OperationVersion {
 
         match Result::map(
             <OperationV1 as serde::Deserialize>::deserialize(
-                serde::__private::de::ContentRefDeserializer::<D::Error>::new(
-                    &content,
-                ),
+                serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
             ),
             OperationVersion::V1,
         ) {
@@ -159,7 +153,9 @@ impl<'de> Deserialize<'de> for OperationVersion {
             }
         }
 
-        Err(D::Error::custom("data did not match any operation log version"))
+        Err(D::Error::custom(
+            "data did not match any operation log version",
+        ))
     }
 }
 

--- a/src/checkers/history/operation/v2.rs
+++ b/src/checkers/history/operation/v2.rs
@@ -533,7 +533,7 @@ mod tests {
                     is_backup: true,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Anonymous(v1::Pile(
-                        maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) },
+                        maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() },
                     )),
                 },
                 v1::OperationV1 {
@@ -541,7 +541,7 @@ mod tests {
                     is_backup: false,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Anonymous(v1::Pile(
-                        maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) },
+                        maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() },
                     )),
                 },
                 v1::OperationV1 {
@@ -605,8 +605,8 @@ mod tests {
                     is_backup: true,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Anonymous(v1::Pile(maplit::hashmap! {
-                        RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("ba9d332813a722b273a95fa13dd88d94".parse().unwrap()),
-                        RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
+                        RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "ba9d332813a722b273a95fa13dd88d94".parse().unwrap(),
+                        RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
                     })),
                 },
                 v1::OperationV1 {
@@ -614,9 +614,9 @@ mod tests {
                     is_backup: true,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Anonymous(v1::Pile(maplit::hashmap! {
-                        RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                        RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
-                        RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap()),
+                        RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                        RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
+                        RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap(),
                     })),
                 },
                 v1::OperationV1 {
@@ -624,8 +624,8 @@ mod tests {
                     is_backup: true,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Anonymous(v1::Pile(maplit::hashmap! {
-                        RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                        RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap()),
+                        RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                        RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap(),
                     })),
                 },
             ];
@@ -704,10 +704,10 @@ mod tests {
                     is_backup: true,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Named(maplit::hashmap! {
-                        "single_file".parse().unwrap() => v1::Pile(maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) }),
+                        "single_file".parse().unwrap() => v1::Pile(maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() }),
                         "dir".parse().unwrap() => v1::Pile(maplit::hashmap! {
-                            RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("ba9d332813a722b273a95fa13dd88d94".parse().unwrap()),
-                            RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
+                            RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "ba9d332813a722b273a95fa13dd88d94".parse().unwrap(),
+                            RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
                         })
                     }),
                 },
@@ -716,11 +716,11 @@ mod tests {
                     is_backup: true,
                     hoard_name: hoard_name.clone(),
                     hoard: v1::Hoard::Named(maplit::hashmap! {
-                        "single_file".parse().unwrap() => v1::Pile(maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) }),
+                        "single_file".parse().unwrap() => v1::Pile(maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() }),
                         "dir".parse().unwrap() => v1::Pile(maplit::hashmap! {
-                            RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                            RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
-                            RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap()),
+                            RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                            RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
+                            RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap(),
                         })
                     }),
                 },
@@ -731,8 +731,8 @@ mod tests {
                     hoard: v1::Hoard::Named(maplit::hashmap! {
                         "single_file".parse().unwrap() => v1::Pile(HashMap::new()),
                         "dir".parse().unwrap() => v1::Pile(maplit::hashmap! {
-                            RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                            RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap()),
+                            RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                            RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap(),
                         })
                     }),
                 },

--- a/tests/hoard_upgrade.rs
+++ b/tests/hoard_upgrade.rs
@@ -12,7 +12,6 @@ use hoard::checkers::history::operation::util::TIME_FORMAT;
 use hoard::checkers::history::operation::v1::{Hoard as HoardV1, OperationV1, Pile as PileV1};
 use hoard::checkers::history::operation::v2::OperationV2;
 use hoard::checkers::history::operation::OperationImpl;
-use hoard::checksum::Checksum;
 use hoard::command::Command;
 use hoard::newtypes::HoardName;
 use hoard::paths::RelativePath;
@@ -28,7 +27,7 @@ fn anon_file_operations() -> Vec<OperationV1> {
             is_backup: true,
             hoard_name: hoard_name.clone(),
             hoard: HoardV1::Anonymous(PileV1::from(
-                maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) },
+                maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() },
             )),
         },
         OperationV1 {
@@ -36,7 +35,7 @@ fn anon_file_operations() -> Vec<OperationV1> {
             is_backup: false,
             hoard_name: hoard_name.clone(),
             hoard: HoardV1::Anonymous(PileV1::from(
-                maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) },
+                maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() },
             )),
         },
         OperationV1 {
@@ -59,8 +58,8 @@ fn anon_dir_operations() -> Vec<OperationV1> {
             is_backup: true,
             hoard_name: hoard_name.clone(),
             hoard: HoardV1::Anonymous(PileV1::from(maplit::hashmap! {
-                RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("ba9d332813a722b273a95fa13dd88d94".parse().unwrap()),
-                RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
+                RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "ba9d332813a722b273a95fa13dd88d94".parse().unwrap(),
+                RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
             })),
         },
         OperationV1 {
@@ -68,9 +67,9 @@ fn anon_dir_operations() -> Vec<OperationV1> {
             is_backup: true,
             hoard_name: hoard_name.clone(),
             hoard: HoardV1::Anonymous(PileV1::from(maplit::hashmap! {
-                RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
-                RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap()),
+                RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
+                RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap(),
             })),
         },
         OperationV1 {
@@ -78,8 +77,8 @@ fn anon_dir_operations() -> Vec<OperationV1> {
             is_backup: true,
             hoard_name,
             hoard: HoardV1::Anonymous(PileV1::from(maplit::hashmap! {
-                RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap()),
+                RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap(),
             })),
         },
     ]
@@ -96,10 +95,10 @@ fn named_operations() -> Vec<OperationV1> {
             is_backup: true,
             hoard_name: hoard_name.clone(),
             hoard: HoardV1::Named(maplit::hashmap! {
-                "single_file".parse().unwrap() => PileV1::from(maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) }),
+                "single_file".parse().unwrap() => PileV1::from(maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() }),
                 "dir".parse().unwrap() => PileV1::from(maplit::hashmap! {
-                    RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("ba9d332813a722b273a95fa13dd88d94".parse().unwrap()),
-                    RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
+                    RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "ba9d332813a722b273a95fa13dd88d94".parse().unwrap(),
+                    RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
                 })
             }),
         },
@@ -108,11 +107,11 @@ fn named_operations() -> Vec<OperationV1> {
             is_backup: true,
             hoard_name: hoard_name.clone(),
             hoard: HoardV1::Named(maplit::hashmap! {
-                "single_file".parse().unwrap() => PileV1::from(maplit::hashmap! { RelativePath::none() => Checksum::MD5("d3369a026ace494f56ead54d502a00dd".parse().unwrap()) }),
+                "single_file".parse().unwrap() => PileV1::from(maplit::hashmap! { RelativePath::none() => "d3369a026ace494f56ead54d502a00dd".parse().unwrap() }),
                 "dir".parse().unwrap() => PileV1::from(maplit::hashmap! {
-                    RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                    RelativePath::try_from(PathBuf::from("file_2")).unwrap() => Checksum::MD5("92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap()),
-                    RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap()),
+                    RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                    RelativePath::try_from(PathBuf::from("file_2")).unwrap() => "92ed3b5f07b44bc4f70d0b24d5e1867c".parse().unwrap(),
+                    RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "797b373a9c4ec0d6de0a31a90b5bee8e".parse().unwrap(),
                 })
             }),
         },
@@ -123,8 +122,8 @@ fn named_operations() -> Vec<OperationV1> {
             hoard: HoardV1::Named(maplit::hashmap! {
                 "single_file".parse().unwrap() => PileV1::from(HashMap::new()),
                 "dir".parse().unwrap() => PileV1::from(maplit::hashmap! {
-                    RelativePath::try_from(PathBuf::from("file_1")).unwrap() => Checksum::MD5("1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap()),
-                    RelativePath::try_from(PathBuf::from("file_3")).unwrap() => Checksum::MD5("1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap()),
+                    RelativePath::try_from(PathBuf::from("file_1")).unwrap() => "1cfab2a192005a9a8bdc69106b4627e2".parse().unwrap(),
+                    RelativePath::try_from(PathBuf::from("file_3")).unwrap() => "1deb21ef3bb87be4ad71d73fff6bb8ec".parse().unwrap(),
                 })
             }),
         },


### PR DESCRIPTION
- Created a shell script that creates operation log files using the released version of Hoard 0.4.0, then runs the `upgrade` command using the current tree.
  - Written in such a way to make it easy to expand to using 0.5.0 if 0.6.0 introduces changes, etc.
- Fixed issues that came up as a result of running the script