### PR TITLE
refactor: log errors at creation site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "similar",
+ "tap",
  "tempfile",
  "thiserror",
  "time",
@@ -904,6 +905,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hostname = "0.3"
 itertools = "0.10"
 md-5 = "0.10.1"
 once_cell = "1.10"
-open_cmd = { version = "0.1.0", features = ["tracing"]}
+open_cmd = { version = "0.1.0", features = ["tracing"] }
 petgraph = "0.6"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
@@ -38,7 +38,7 @@ tempfile = "3.3"
 thiserror = "1.0.30"
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "serde", "std"] }
 tokio = { version = "1.18", default-features = false, features = ["rt-multi-thread", "fs", "io-util", "macros"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["fs"]}
+tokio-stream = { version = "0.1", default-features = false, features = ["fs"] }
 toml = "0.5.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt", "env-filter", "smallvec", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0"
 serde_yaml = { version = "0.8", optional = true }
 sha2 = "0.10.2"
 similar = { version = "2.1", default-features = false, features = ["text"] }
+tap = "1.0"
 tempfile = "3.3"
 thiserror = "1.0.30"
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "serde", "std"] }

--- a/src/checkers/history/mod.rs
+++ b/src/checkers/history/mod.rs
@@ -1,12 +1,14 @@
 //! Keep records of previous operations (including on other system) to prevent inconsistencies
 //! and accidental overwrites or deletions.
 
-use crate::paths::{HoardPath, RelativePath};
-use futures::TryStreamExt;
 use std::path::PathBuf;
+
+use futures::TryStreamExt;
 use tokio::{fs, io};
 use tokio_stream::wrappers::ReadDirStream;
 use uuid::Uuid;
+
+use crate::paths::{HoardPath, RelativePath};
 
 pub mod last_paths;
 pub mod operation;
@@ -14,27 +16,27 @@ pub mod operation;
 const UUID_FILE_NAME: &str = "uuid";
 const HISTORY_DIR_NAME: &str = "history";
 
+#[tracing::instrument(level = "debug")]
 fn get_uuid_file() -> PathBuf {
-    let _span = tracing::debug_span!("get_uuid_file").entered();
     crate::dirs::config_dir().join(UUID_FILE_NAME)
 }
 
+#[tracing::instrument(level = "debug")]
 fn get_history_root_dir() -> HoardPath {
-    let _span = tracing::debug_span!("get_history_root_dir").entered();
     HoardPath::try_from(crate::dirs::data_dir().join(HISTORY_DIR_NAME))
         .expect("directory rooted in the data dir is always a valid hoard path")
 }
 
+#[tracing::instrument(level = "debug")]
 fn get_history_dir_for_id(id: Uuid) -> HoardPath {
-    let _span = tracing::debug_span!("get_history_dir_for_id", %id).entered();
     get_history_root_dir().join(
         &RelativePath::try_from(PathBuf::from(id.to_string()))
             .expect("uuid is always a valid relative path"),
     )
 }
 
+#[tracing::instrument(level = "debug")]
 async fn get_history_dirs_not_for_id(id: &Uuid) -> Result<Vec<HoardPath>, io::Error> {
-    let _span = tracing::debug_span!("get_history_dir_not_for_id", %id).entered();
     let root = get_history_root_dir();
     if !root.exists() {
         tracing::trace!("history root dir does not exist");

--- a/src/checkers/history/operation/mod.rs
+++ b/src/checkers/history/operation/mod.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use futures::stream::TryStreamExt;
-use serde::{Deserialize, Serialize};
 use serde::de::Error as _;
+use serde::{Deserialize, Serialize};
 use tap::tap::TapFallible;
 use thiserror::Error;
 use time::OffsetDateTime;
@@ -14,10 +14,10 @@ use tokio_stream::wrappers::ReadDirStream;
 
 pub(crate) use util::cleanup_operations;
 
-use crate::checkers::Checker;
 use crate::checkers::history::operation::util::TIME_FORMAT;
 use crate::checkers::history::operation::v1::OperationV1;
 use crate::checkers::history::operation::v2::OperationV2;
+use crate::checkers::Checker;
 use crate::checksum::Checksum;
 use crate::hoard::{Direction, Hoard};
 use crate::hoard_item::HoardItem;
@@ -122,8 +122,8 @@ enum OperationVersion {
 impl<'de> Deserialize<'de> for OperationVersion {
     #[tracing::instrument(skip_all, name = "deserialize_operation")]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
     {
         let content =
             match <serde::__private::de::Content as Deserialize>::deserialize(deserializer) {
@@ -158,7 +158,7 @@ impl<'de> Deserialize<'de> for OperationVersion {
         }
 
         crate::create_log_error(D::Error::custom(
-            "data did not match any operation log version"
+            "data did not match any operation log version",
         ))
     }
 }
@@ -184,7 +184,7 @@ pub trait OperationImpl {
     fn checksum_for(&self, pile_name: &PileName, rel_path: &RelativePath) -> Option<Checksum>;
     /// An iterator over all files that exist within this operation log, not including any that
     /// were deleted.
-    fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item=OperationFileInfo> + 'a>;
+    fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item = OperationFileInfo> + 'a>;
     /// Returns an iterator of the file operations represented by this operation object.
     ///
     /// # Errors
@@ -195,7 +195,7 @@ pub trait OperationImpl {
         &'a self,
         _hoard_path: &HoardPath,
         _hoard: &Hoard,
-    ) -> Result<Box<dyn Iterator<Item=ItemOperation<HoardItem>> + 'a>, Error> {
+    ) -> Result<Box<dyn Iterator<Item = ItemOperation<HoardItem>> + 'a>, Error> {
         crate::create_log_error(Error::UpgradeRequired)
     }
 
@@ -257,7 +257,7 @@ impl OperationImpl for OperationVersion {
         }
     }
 
-    fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item=OperationFileInfo> + 'a> {
+    fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item = OperationFileInfo> + 'a> {
         match &self {
             OperationVersion::V1(one) => one.all_files_with_checksums(),
             OperationVersion::V2(two) => two.all_files_with_checksums(),
@@ -268,7 +268,7 @@ impl OperationImpl for OperationVersion {
         &'a self,
         hoard_root: &HoardPath,
         hoard: &Hoard,
-    ) -> Result<Box<dyn Iterator<Item=ItemOperation<HoardItem>> + 'a>, Error> {
+    ) -> Result<Box<dyn Iterator<Item = ItemOperation<HoardItem>> + 'a>, Error> {
         match &self {
             OperationVersion::V1(v1) => v1.hoard_operations_iter(hoard_root, hoard),
             OperationVersion::V2(v2) => v2.hoard_operations_iter(hoard_root, hoard),
@@ -320,7 +320,7 @@ impl OperationImpl for Operation {
         self.0.checksum_for(pile_name, rel_path)
     }
 
-    fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item=OperationFileInfo> + 'a> {
+    fn all_files_with_checksums<'a>(&'a self) -> Box<dyn Iterator<Item = OperationFileInfo> + 'a> {
         self.0.all_files_with_checksums()
     }
 
@@ -328,7 +328,7 @@ impl OperationImpl for Operation {
         &'a self,
         hoard_root: &HoardPath,
         hoard: &Hoard,
-    ) -> Result<Box<dyn Iterator<Item=ItemOperation<HoardItem>> + 'a>, Error> {
+    ) -> Result<Box<dyn Iterator<Item = ItemOperation<HoardItem>> + 'a>, Error> {
         self.0.hoard_operations_iter(hoard_root, hoard)
     }
 
@@ -614,7 +614,7 @@ impl Checker for Operation {
                         .map_err(Error::FormatDatetime)
                         .tap_err(crate::tap_log_error)?
                 )))
-                    .expect("file name is always a valid RelativePath"),
+                .expect("file name is always a valid RelativePath"),
             );
         tracing::trace!(path=%path.display(), "ensuring parent directories for operation log file");
         if let Some(parent) = path.parent() {

--- a/src/checkers/history/operation/mod.rs
+++ b/src/checkers/history/operation/mod.rs
@@ -608,7 +608,7 @@ impl Checker for Operation {
                 self.check_has_same_files(&last_remote)
                     .map(|list_op| match list_op {
                         None => Ok(()),
-                        Some(_) => Err(error),
+                        Some(_) => crate::create_log_error(error),
                     })?
             }
             (Some(last_local), Some(last_remote)) => {
@@ -628,7 +628,7 @@ impl Checker for Operation {
                             if matches_previous {
                                 Ok(())
                             } else {
-                                Err(error)
+                                crate::create_log_error(error)
                             }
                         }
                     }

--- a/src/checkers/history/operation/mod.rs
+++ b/src/checkers/history/operation/mod.rs
@@ -79,8 +79,12 @@ impl ItemOperation<CachedHoardItem> {
             ItemOperation::Create(file) => format!("create {}", file.system_path().display()),
             ItemOperation::Modify(file) => format!("modify {}", file.system_path().display()),
             ItemOperation::Delete(file) => format!("delete {}", file.system_path().display()),
-            ItemOperation::Nothing(file) => format!("do nothing with {}", file.system_path().display()),
-            ItemOperation::DoesNotExist(file) => format!("{} does not exist", file.system_path().display()),
+            ItemOperation::Nothing(file) => {
+                format!("do nothing with {}", file.system_path().display())
+            }
+            ItemOperation::DoesNotExist(file) => {
+                format!("{} does not exist", file.system_path().display())
+            }
         }
     }
 }
@@ -606,7 +610,7 @@ impl Checker for Operation {
                         None => Ok(()),
                         Some(_) => Err(error),
                     })?
-            },
+            }
             (Some(last_local), Some(last_remote)) => {
                 if last_local.timestamp() > last_remote.timestamp() {
                     // Allow if the last operation on this machine
@@ -618,7 +622,8 @@ impl Checker for Operation {
                             // Check if any of the files are unchanged compared to when last seen
                             // This can happen if the file is deleted and then recreated remotely
                             let matches_previous = list.into_iter().all(|item| {
-                                item.checksum == last_local.checksum_for(&item.pile_name, &item.relative_path)
+                                item.checksum
+                                    == last_local.checksum_for(&item.pile_name, &item.relative_path)
                             });
                             if matches_previous {
                                 Ok(())

--- a/src/checkers/history/operation/util.rs
+++ b/src/checkers/history/operation/util.rs
@@ -285,6 +285,7 @@ async fn sorted_operations() -> Result<Vec<Operation>, Error> {
 
 #[tracing::instrument(level = "trace")]
 pub(crate) async fn upgrade_operations() -> Result<(), Error> {
+    tracing::debug!("upgrading operation files to latest version");
     let mut top_file_checksum_map = HashMap::new();
     let mut top_file_set = HashMap::new();
 

--- a/src/checkers/history/operation/v2.rs
+++ b/src/checkers/history/operation/v2.rs
@@ -306,6 +306,7 @@ impl Hoard {
     ) -> Result<Checksum, Error> {
         checksum
             .ok_or_else(|| {
+                tracing::error!("expected checksum for {} but found nothing", path);
                 Error::IO(io::Error::new(
                     io::ErrorKind::NotFound,
                     format!("could not find item at \"{}\"", path),

--- a/src/checkers/history/operation/v2.rs
+++ b/src/checkers/history/operation/v2.rs
@@ -45,7 +45,7 @@ pub struct OperationV2 {
 }
 
 impl OperationV2 {
-    #[tracing::instrument(level = "trace", name = "new_operation_v2")]
+    #[tracing::instrument(level = "trace", name = "new_operation_v2", skip(hoard))]
     pub(super) async fn new(
         hoards_root: &HoardPath,
         name: &HoardName,
@@ -332,7 +332,7 @@ impl Hoard {
         .unwrap_or_default()
     }
 
-    #[tracing::instrument(name = "v2_new_hoard")]
+    #[tracing::instrument(name = "v2_new_hoard", skip(hoard))]
     async fn new(
         hoards_root: &HoardPath,
         hoard_name: &HoardName,
@@ -344,6 +344,7 @@ impl Hoard {
                 .await?
                 .map_err(Error::Iterator)
                 .try_fold(HashMap::new(), |mut acc, op| async move {
+                    tracing::debug!(operation=%op.short_name(), "pending operation");
                     match op {
                         ItemOperation::Create(file) => {
                             let checksum = match direction {

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -92,7 +92,7 @@ impl Checkers {
         })
     }
 
-    #[tracing::instrument(level = "debug", name = "checkers_check")]
+    #[tracing::instrument(level = "debug", name = "checkers_check", skip_all)]
     pub(crate) async fn check(&mut self) -> Result<(), Error> {
         for last_path in &mut self.last_paths.values_mut() {
             last_path.check().await?;
@@ -103,7 +103,7 @@ impl Checkers {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", name = "checkers_commit")]
+    #[tracing::instrument(level = "debug", name = "checkers_commit", skip_all)]
     pub(crate) async fn commit_to_disk(self) -> Result<(), Error> {
         let Self {
             last_paths,

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -75,7 +75,6 @@ impl Checkers {
         hoards: impl IntoIterator<Item = (&'a HoardName, &'a Hoard)>,
         direction: Direction,
     ) -> Result<Self, Error> {
-        let _span = tracing::debug_span!("create_checkers", ?hoards_root).entered();
         let mut last_paths = HashMap::new();
         let mut operations = HashMap::new();
 
@@ -95,7 +94,6 @@ impl Checkers {
 
     #[tracing::instrument(level = "debug", name = "checkers_check")]
     pub(crate) async fn check(&mut self) -> Result<(), Error> {
-        let _span = tracing::debug_span!("running_checks").entered();
         for last_path in &mut self.last_paths.values_mut() {
             last_path.check().await?;
         }

--- a/src/checkers/mod.rs
+++ b/src/checkers/mod.rs
@@ -3,21 +3,23 @@
 //! This module includes a single trait, [`Checker`], and all types that implement it.
 //! Currently, that is only the [`LastPaths`](history::last_paths::LastPaths) checker.
 
-pub mod history;
+use std::collections::HashMap;
+
+use thiserror::Error;
 
 use crate::checkers::history::last_paths::{Error as LastPathsError, LastPaths};
 use crate::checkers::history::operation::{Error as OperationError, Operation};
 use crate::hoard::{Direction, Hoard};
 use crate::newtypes::HoardName;
 use crate::paths::HoardPath;
-use std::collections::HashMap;
-use thiserror::Error;
+
+pub mod history;
 
 /// Trait for validating [`Hoard`]s.
 ///
 /// A [`Checker`] takes a [`Hoard`] and its name (as [`&str`]) as parameters and uses that
 /// information plus any internal state to validate that it is safe to operate on that [`Hoard`].
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait(? Send)]
 pub trait Checker: Sized + Unpin {
     /// The error type returned from the check.
     type Error: std::error::Error;
@@ -67,6 +69,7 @@ pub(crate) struct Checkers {
 
 impl Checkers {
     #[allow(single_use_lifetimes)]
+    #[tracing::instrument(level = "debug", name = "checkers_new", skip(hoards))]
     pub(crate) async fn new<'a>(
         hoards_root: &HoardPath,
         hoards: impl IntoIterator<Item = (&'a HoardName, &'a Hoard)>,
@@ -90,6 +93,7 @@ impl Checkers {
         })
     }
 
+    #[tracing::instrument(level = "debug", name = "checkers_check")]
     pub(crate) async fn check(&mut self) -> Result<(), Error> {
         let _span = tracing::debug_span!("running_checks").entered();
         for last_path in &mut self.last_paths.values_mut() {
@@ -101,6 +105,7 @@ impl Checkers {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", name = "checkers_commit")]
     pub(crate) async fn commit_to_disk(self) -> Result<(), Error> {
         let Self {
             last_paths,

--- a/src/checksum/digest.rs
+++ b/src/checksum/digest.rs
@@ -79,7 +79,6 @@ pub enum Error {
     },
 }
 
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct Digest<T>(GenericArray<u8, T::OutputSize>)
 where
@@ -178,6 +177,16 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", checksum_to_string(&self.0))
+    }
+}
+
+impl<T> fmt::Debug for Digest<T>
+where
+    T: Digestable,
+    <<T as Digestable>::OutputSize as Add>::Output: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -168,7 +168,9 @@ where
     ///
     /// Any errors during the serialization process ([`toml::ser::Error`]).
     pub fn to_toml_string(&self) -> Result<String, toml::ser::Error> {
-        toml::to_string(&self).tap_err(crate::tap_log_error_msg("failed to serialize combinator as TOML"))
+        toml::to_string(&self).tap_err(crate::tap_log_error_msg(
+            "failed to serialize combinator as TOML",
+        ))
     }
 }
 

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::error::Error;
 use std::fmt::Formatter;
+use tap::TapFallible;
 
 /// An internal container for the [`Combinator<T>`] type.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
@@ -167,7 +168,7 @@ where
     ///
     /// Any errors during the serialization process ([`toml::ser::Error`]).
     pub fn to_toml_string(&self) -> Result<String, toml::ser::Error> {
-        toml::to_string(&self)
+        toml::to_string(&self).tap_err(crate::tap_log_error_msg("failed to serialize combinator as TOML"))
     }
 }
 

--- a/src/command/backup_restore.rs
+++ b/src/command/backup_restore.rs
@@ -170,7 +170,7 @@ async fn create_all_with_perms(
     Ok(())
 }
 
-#[tracing::instrument]
+#[tracing::instrument(fields(file = ?file.system_path()))]
 async fn copy_file(file: &HoardItem, direction: Direction) -> Result<(), Error> {
     let (src, dest, dest_root) = match direction {
         Direction::Backup => (
@@ -207,7 +207,7 @@ async fn copy_file(file: &HoardItem, direction: Direction) -> Result<(), Error> 
     Ok(())
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip(hoard))]
 async fn fix_permissions(
     hoard: &Hoard,
     operation: &ItemOperation<HoardItem>,
@@ -282,7 +282,6 @@ async fn backup_or_restore<'a>(
             .hoard_operations_iter(&hoard_prefix, hoard)
             .map_err(ConsistencyError::Operation)?;
         for operation in iter {
-            tracing::trace!("found operation: {:?}", operation);
             match &operation {
                 ItemOperation::Create(file) | ItemOperation::Modify(file) => {
                     copy_file(file, direction).await?;

--- a/src/command/cleanup.rs
+++ b/src/command/cleanup.rs
@@ -1,5 +1,6 @@
 use crate::checkers::history::operation::cleanup_operations;
 
+#[tracing::instrument]
 pub(crate) async fn run_cleanup() -> Result<(), super::Error> {
     match cleanup_operations().await {
         Ok(count) => {

--- a/src/command/diff.rs
+++ b/src/command/diff.rs
@@ -7,7 +7,7 @@ use crate::hoard::Hoard;
 use crate::newtypes::HoardName;
 use crate::paths::HoardPath;
 
-#[tracing::instrument]
+#[tracing::instrument(skip(hoard))]
 pub(crate) async fn run_diff(
     hoard: &Hoard,
     hoard_name: &HoardName,

--- a/src/command/diff.rs
+++ b/src/command/diff.rs
@@ -1,11 +1,13 @@
-use crate::hoard::iter::{changed_diff_only_stream, HoardFileDiff};
-use crate::hoard::Hoard;
-use crate::paths::HoardPath;
-use futures::TryStreamExt;
 use std::collections::BTreeSet;
 
-use crate::newtypes::HoardName;
+use futures::TryStreamExt;
 
+use crate::hoard::iter::{changed_diff_only_stream, HoardFileDiff};
+use crate::hoard::Hoard;
+use crate::newtypes::HoardName;
+use crate::paths::HoardPath;
+
+#[tracing::instrument]
 pub(crate) async fn run_diff(
     hoard: &Hoard,
     hoard_name: &HoardName,

--- a/src/command/edit.rs
+++ b/src/command/edit.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use atty::Stream;
+use tap::TapFallible;
 use thiserror::Error;
 use tokio::{fs, io};
 
@@ -45,36 +46,52 @@ const DEFAULT_CONFIG: &str = include_str!("../../config.toml.sample");
 /// See [`Error`].
 #[tracing::instrument]
 pub(crate) async fn run_edit(path: &Path) -> Result<(), super::Error> {
-    let tmp_dir = tempfile::tempdir().map_err(Error::IO)?;
+    let tmp_dir = tempfile::tempdir().map_err(Error::IO).tap_err(|error| {
+        tracing::error!(%error, "failed to create temporary file for editing");
+    })?;
     let tmp_file = tmp_dir.path().join(
         path.file_name()
             .ok_or_else(|| Error::IsDirectory(path.to_path_buf()))?,
     );
 
     if path.exists() {
-        fs::copy(path, &tmp_file).await.map_err(Error::IO)?;
+        fs::copy(path, &tmp_file).await.map_err(|error| {
+            tracing::error!(%error, "failed to copy config file ({}) to temporary file ({})", path.display(), tmp_file.display());
+            Error::IO(error)
+        })?;
     } else {
         fs::write(&tmp_file, DEFAULT_CONFIG.as_bytes())
             .await
-            .map_err(Error::IO)?;
+            .map_err(|error| {
+                tracing::error!(%error, "failed to write default sample config to temporary file ({})", tmp_file.display());
+                Error::IO(error)
+            })?;
     }
 
     let mut cmd = if atty::is(Stream::Stdout) && atty::is(Stream::Stderr) && atty::is(Stream::Stdin)
     {
-        open_cmd::open_editor(tmp_file.clone()).map_err(Error::Start)?
+        open_cmd::open_editor(tmp_file.clone()).map_err(|error| {
+            tracing::error!(%error, "failed to generate CLI editor command");
+            Error::Start(error)
+        })?
     } else {
-        open_cmd::open(tmp_file.clone()).map_err(Error::Start)?
+        open_cmd::open(tmp_file.clone()).map_err(|error| {
+            tracing::error!(%error, "failed to generate editor command");
+            Error::Start(error)
+        })?
     };
 
-    let status = cmd
-        .status()
-        .map_err(open_cmd::Error::from)
-        .map_err(Error::Start)
-        .map_err(super::Error::Edit)?;
+    let status = cmd.status().map_err(|error| {
+        tracing::error!(%error, "failed to run editor command");
+        super::Error::Edit(Error::Start(open_cmd::Error::from(error)))
+    })?;
 
     if status.success() {
         tracing::debug!("editing exited without error, copying temporary file back to original");
-        fs::copy(tmp_file, path).await.map_err(Error::IO)?;
+        fs::copy(&tmp_file, path).await.map_err(|error| {
+            tracing::error!(%error, "failed to copy temporary file ({}) to config file location ({})", tmp_file.display(), path.display());
+            Error::IO(error)
+        })?;
     } else {
         tracing::error!("edit command exited with status {}", status);
         return Err(super::Error::Edit(Error::Exit(status)));

--- a/src/command/edit.rs
+++ b/src/command/edit.rs
@@ -1,8 +1,9 @@
-use atty::Stream;
 use std::{
     path::{Path, PathBuf},
     process::ExitStatus,
 };
+
+use atty::Stream;
 use thiserror::Error;
 use tokio::{fs, io};
 
@@ -42,9 +43,8 @@ const DEFAULT_CONFIG: &str = include_str!("../../config.toml.sample");
 /// # Errors
 ///
 /// See [`Error`].
+#[tracing::instrument]
 pub(crate) async fn run_edit(path: &Path) -> Result<(), super::Error> {
-    let _span = tracing::trace_span!("edit", ?path).entered();
-
     let tmp_dir = tempfile::tempdir().map_err(Error::IO)?;
     let tmp_file = tmp_dir.path().join(
         path.file_name()

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -1,6 +1,7 @@
 use crate::newtypes::HoardName;
 
 #[allow(single_use_lifetimes)]
+#[tracing::instrument(skip_all)]
 pub(crate) fn run_list<'a>(hoard_names_iter: impl IntoIterator<Item = &'a HoardName>) {
     let mut hoards: Vec<_> = hoard_names_iter.into_iter().map(AsRef::as_ref).collect();
     hoards.sort_unstable();

--- a/src/command/status.rs
+++ b/src/command/status.rs
@@ -1,9 +1,11 @@
+use futures::TryStreamExt;
+
 use crate::hoard::iter::{diff_stream, DiffSource, HoardFileDiff};
 use crate::hoard::Hoard;
 use crate::newtypes::HoardName;
 use crate::paths::HoardPath;
-use futures::TryStreamExt;
 
+#[tracing::instrument(skip(hoards))]
 pub(crate) async fn run_status<'a>(
     hoards_root: &HoardPath,
     hoards: impl IntoIterator<Item = (&'a HoardName, &'a Hoard)>,

--- a/src/command/upgrade.rs
+++ b/src/command/upgrade.rs
@@ -1,6 +1,7 @@
+use thiserror::Error;
+
 use crate::checkers::history::operation::util::upgrade_operations;
 use crate::checkers::history::operation::Error as OperationError;
-use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -8,8 +9,8 @@ pub enum Error {
     Operations(OperationError),
 }
 
+#[tracing::instrument]
 pub(crate) async fn run_upgrade() -> Result<(), super::Error> {
-    let _span = tracing::trace_span!("run_upgrade").entered();
     tracing::info!("Upgrading operation logs to the latest format...");
     match upgrade_operations().await {
         Ok(_) => {

--- a/src/command/upgrade.rs
+++ b/src/command/upgrade.rs
@@ -12,14 +12,10 @@ pub enum Error {
 #[tracing::instrument]
 pub(crate) async fn run_upgrade() -> Result<(), super::Error> {
     tracing::info!("Upgrading operation logs to the latest format...");
-    match upgrade_operations().await {
-        Ok(_) => {
-            tracing::info!("Successfully upgraded all operation logs");
-            Ok(())
-        }
-        Err(err) => {
-            tracing::error!("Failed to upgrade operation logs: {}", err);
-            Err(super::Error::Upgrade(Error::Operations(err)))
-        }
-    }
+    upgrade_operations()
+        .await
+        .map_err(Error::Operations)
+        .map_err(super::Error::Upgrade)?;
+    tracing::info!("Successfully upgraded all operation logs");
+    Ok(())
 }

--- a/src/config/builder/environment/exe.rs
+++ b/src/config/builder/environment/exe.rs
@@ -1,6 +1,5 @@
 //! See [`ExeExists`].
 
-use std::{fs, io};
 use std::convert::TryInto;
 use std::fmt;
 use std::fmt::Debug;
@@ -8,6 +7,7 @@ use std::ops::Deref;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::{fs, io};
 
 use serde::{Deserialize, Serialize};
 use tap::TapFallible;

--- a/src/config/builder/environment/exe.rs
+++ b/src/config/builder/environment/exe.rs
@@ -1,16 +1,16 @@
 //! See [`ExeExists`].
 
-use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
-use std::{fs, io};
-use thiserror::Error;
-
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// The contained path was not a valid [`Executable`].
 ///
@@ -70,6 +70,7 @@ impl From<Executable> for PathBuf {
 impl TryFrom<PathBuf> for Executable {
     type Error = InvalidPathError;
 
+    #[tracing::instrument(name = "new_executable")]
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
         let is_lone_file_name = value.parent().map_or(false, |s| s.as_os_str().is_empty());
         if value.is_absolute() || is_lone_file_name {

--- a/src/config/builder/environment/hostname.rs
+++ b/src/config/builder/environment/hostname.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::fmt;
 use std::fmt::Formatter;
+use tap::TapFallible;
 
 /// A conditional structure that compares the system's hostname to the given string.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Hash)]
@@ -15,7 +16,9 @@ impl TryInto<bool> for Hostname {
 
     fn try_into(self) -> Result<bool, super::Error> {
         let Hostname(expected) = self;
-        let host = hostname::get().map_err(super::Error::Hostname)?;
+        let host = hostname::get()
+            .map_err(super::Error::Hostname)
+            .tap_err(crate::tap_log_error)?;
 
         // grcov: ignore-start
         tracing::trace!(

--- a/src/config/builder/environment/mod.rs
+++ b/src/config/builder/environment/mod.rs
@@ -1,22 +1,24 @@
 //! Environment definitions. For more, see [`Environment`].
 
-pub mod envvar;
-pub mod exe;
-pub mod hostname;
-pub mod os;
-pub mod path;
+use std::convert::{Infallible, TryInto};
+use std::fmt;
 
-use crate::combinator::Combinator;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::combinator::Combinator;
 
 pub use self::envvar::EnvVariable;
 pub use self::exe::ExeExists;
 pub use self::hostname::Hostname;
 pub use self::os::OperatingSystem;
 pub use self::path::PathExists;
-use std::convert::{Infallible, TryInto};
-use std::fmt;
+
+pub mod envvar;
+pub mod exe;
+pub mod hostname;
+pub mod os;
+pub mod path;
 
 /// Errors that may occur while evaluating an [`Environment`].
 #[derive(Debug, Error)]
@@ -123,6 +125,7 @@ impl fmt::Display for Environment {
         Ok(())
     }
 }
+
 // Note to self: this is a good candidate for a derive macro
 // if Combinator is put into its own library
 impl TryInto<bool> for Environment {
@@ -153,6 +156,7 @@ impl Environment {
     /// # Errors
     ///
     /// [`Error::InvalidCondition`]
+    #[tracing::instrument(name = "validate_environment")]
     pub fn validate(&self) -> Result<(), Error> {
         let Environment { hostname, os, .. } = self;
         if let Some(comb) = hostname {
@@ -181,13 +185,16 @@ impl Environment {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::combinator::Inner;
 
+    use super::*;
+
     mod display {
-        use super::*;
-        use crate::paths::SystemPath;
         use std::path::PathBuf;
+
+        use crate::paths::SystemPath;
+
+        use super::*;
 
         #[test]
         fn test_display_with_none() {

--- a/src/config/builder/environment/mod.rs
+++ b/src/config/builder/environment/mod.rs
@@ -212,9 +212,9 @@ mod tests {
             let exe_exists = ExeExists(PathBuf::from("test").try_into().unwrap());
             let path_exists = PathExists(Some(
                 #[cfg(unix)]
-                    SystemPath::try_from(PathBuf::from("/test/path")).unwrap(),
+                SystemPath::try_from(PathBuf::from("/test/path")).unwrap(),
                 #[cfg(windows)]
-                    SystemPath::try_from(PathBuf::from("C:\\test\\path")).unwrap(),
+                SystemPath::try_from(PathBuf::from("C:\\test\\path")).unwrap(),
             ));
 
             let env = Environment {
@@ -232,7 +232,7 @@ mod tests {
                 format!("({})", exe_exists),
                 format!("({})", path_exists),
             ]
-                .join(" AND ");
+            .join(" AND ");
 
             assert_eq!(env.to_string(), expected);
         }

--- a/src/config/builder/environment/mod.rs
+++ b/src/config/builder/environment/mod.rs
@@ -161,7 +161,7 @@ impl Environment {
         let Environment { hostname, os, .. } = self;
         if let Some(comb) = hostname {
             if comb.is_only_and() || comb.is_complex() {
-                return Err(Error::InvalidCondition {
+                return crate::create_log_error(Error::InvalidCondition {
                     condition_str: comb.to_string(),
                     message: String::from("machines cannot have multiple hostnames at once!"),
                 });
@@ -170,7 +170,7 @@ impl Environment {
 
         if let Some(comb) = os {
             if comb.is_only_and() || comb.is_complex() {
-                return Err(Error::InvalidCondition {
+                return crate::create_log_error(Error::InvalidCondition {
                     condition_str: comb.to_string(),
                     message: String::from(
                         "machines cannot have multiple operating systems at once!",
@@ -212,9 +212,9 @@ mod tests {
             let exe_exists = ExeExists(PathBuf::from("test").try_into().unwrap());
             let path_exists = PathExists(Some(
                 #[cfg(unix)]
-                SystemPath::try_from(PathBuf::from("/test/path")).unwrap(),
+                    SystemPath::try_from(PathBuf::from("/test/path")).unwrap(),
                 #[cfg(windows)]
-                SystemPath::try_from(PathBuf::from("C:\\test\\path")).unwrap(),
+                    SystemPath::try_from(PathBuf::from("C:\\test\\path")).unwrap(),
             ));
 
             let env = Environment {
@@ -232,7 +232,7 @@ mod tests {
                 format!("({})", exe_exists),
                 format!("({})", path_exists),
             ]
-            .join(" AND ");
+                .join(" AND ");
 
             assert_eq!(env.to_string(), expected);
         }

--- a/src/config/builder/envtrie.rs
+++ b/src/config/builder/envtrie.rs
@@ -109,9 +109,10 @@ impl<'a> Evaluation<'a> {
                     match rel_score.cmp(&0) {
                         Ordering::Less => Ok(false),
                         Ordering::Greater => Ok(true),
-                        Ordering::Equal => {
-                            crate::create_log_error(Error::Indecision(self.name.clone(), other.name.clone()))
-                        }
+                        Ordering::Equal => crate::create_log_error(Error::Indecision(
+                            self.name.clone(),
+                            other.name.clone(),
+                        )),
                     }
                 }
             },
@@ -125,7 +126,7 @@ impl Node {
         if let (Some(first), Some(second)) = (&self.value, &other.value) {
             // Make order of paths deterministic
             #[cfg(test)]
-                let (first, second) = if first < second {
+            let (first, second) = if first < second {
                 (first, second)
             } else {
                 (second, first) // grcov: ignore
@@ -191,7 +192,7 @@ impl Node {
                     %name,
                     ?node
                 )
-                    .entered();
+                .entered();
                 // Ignore non-matching envs.
                 // Error on environments that don't exist.
                 if !envs
@@ -290,10 +291,12 @@ fn get_weighted_map(
         }
     }
 
-    toposort(&score_dag, None).map_err(|cycle| {
-        let node: &EnvironmentName = &score_dag[cycle.node_id()];
-        Error::WeightCycle(node.clone())
-    }).tap_err(crate::tap_log_error)?;
+    toposort(&score_dag, None)
+        .map_err(|cycle| {
+            let node: &EnvironmentName = &score_dag[cycle.node_id()];
+            Error::WeightCycle(node.clone())
+        })
+        .tap_err(crate::tap_log_error)?;
 
     // Actually calculate map
     tracing::trace!("calculating environment weights from exclusivity lists");
@@ -388,7 +391,9 @@ impl EnvTrie {
                     for env2 in env_str.iter().skip(i + 1) {
                         if let Some(set) = exclusivity_map.get(env1) {
                             if set.contains(env2) {
-                                return crate::create_log_error(Error::CombinedMutuallyExclusive(env_str.clone()));
+                                return crate::create_log_error(Error::CombinedMutuallyExclusive(
+                                    env_str.clone(),
+                                ));
                             }
                         }
                     }

--- a/src/config/builder/mod.rs
+++ b/src/config/builder/mod.rs
@@ -326,7 +326,6 @@ impl Builder {
     /// Set the command that will be run.
     #[must_use]
     pub fn set_command(mut self, cmd: Command) -> Self {
-        tracing::trace!(command = ?cmd, "setting command");
         self.command = Some(cmd);
         self
     }
@@ -345,7 +344,7 @@ impl Builder {
     /// # Errors
     ///
     /// Any error that occurs while evaluating the environments.
-    #[tracing::instrument(level = "trace")]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn evaluated_environments(&self) -> Result<BTreeMap<EnvironmentName, bool>, Error> {
         if let Some(envs) = &self.environments {
             for (key, env) in envs {
@@ -371,9 +370,10 @@ impl Builder {
     /// # Errors
     ///
     /// Any [`enum@Error`] that occurs while evaluating environment or hoard definitions.
-    #[tracing::instrument(name = "build_config")]
+    #[tracing::instrument(name = "build_config", skip_all)]
     pub fn build(mut self) -> Result<Config, Error> {
         tracing::debug!("building configuration from builder");
+        tracing::trace!(builder=?self);
         let environments = self.evaluated_environments()?;
         tracing::debug!(?environments);
         let exclusivity = self.exclusivity.unwrap_or_default();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tap::TapFallible;
 
 use thiserror::Error;
 
@@ -109,6 +110,7 @@ impl Config {
         self.hoards
             .get(name)
             .ok_or_else(|| Error::NoSuchHoard(name.clone()))
+            .tap_err(crate::tap_log_error)
     }
 
     /// Run the stored [`Command`] using this [`Config`].

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -78,6 +78,7 @@ impl Config {
             .map(Builder::build)?
             .map_err(Error::Builder)?;
         tracing::debug!("loaded configuration.");
+        tracing::trace!(?config);
         Ok(config)
     }
 
@@ -87,7 +88,7 @@ impl Config {
         self.config_file.clone()
     }
 
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", name = "config_get_hoard", skip(self))]
     fn get_hoards<'a>(
         &'a self,
         hoards: &'a [HoardName],
@@ -105,7 +106,7 @@ impl Config {
         }
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(name = "config_get_hoard", skip(self))]
     fn get_hoard<'a>(&'a self, name: &'_ HoardName) -> Result<&'a Hoard, Error> {
         self.hoards
             .get(name)
@@ -118,7 +119,7 @@ impl Config {
     /// # Errors
     ///
     /// Any [`enum@Error`] that might happen while running the command.
-    #[tracing::instrument(name = "run_command")]
+    #[tracing::instrument(name = "run_command", skip(self))]
     pub async fn run(&self) -> Result<(), Error> {
         tracing::trace!(command = ?self.command, "running command");
         match &self.command {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -19,6 +19,7 @@ pub enum FileContent {
 }
 
 impl FileContent {
+    #[tracing::instrument(level = "debug")]
     pub async fn read(mut file: fs::File) -> io::Result<Self> {
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes).await?;
@@ -28,6 +29,7 @@ impl FileContent {
         }
     }
 
+    #[tracing::instrument(level = "debug")]
     pub async fn read_path(path: &Path) -> io::Result<Self> {
         match fs::File::open(path).await {
             Ok(file) => FileContent::read(file).await,
@@ -38,6 +40,7 @@ impl FileContent {
         }
     }
 
+    #[tracing::instrument(level = "debug")]
     pub fn as_bytes(&self) -> Option<&[u8]> {
         match self {
             Self::Text(s) => Some(s.as_bytes()),

--- a/src/dirs/mod.rs
+++ b/src/dirs/mod.rs
@@ -1,6 +1,7 @@
 //! Functions to determine special folders for Hoard to work with on different platforms.
 use std::path::{Path, PathBuf};
 
+use once_cell::sync::Lazy;
 #[cfg(windows)]
 pub use windows::Win32::UI::Shell::{FOLDERID_Profile, FOLDERID_RoamingAppData};
 
@@ -27,6 +28,8 @@ pub const DATA_DIR_ENV: &str = "HOARD_DATA_DIR";
 /// The environment variable that takes precendence over config dir detection.
 pub const CONFIG_DIR_ENV: &str = "HOARD_CONFIG_DIR";
 
+static EMPTY_SPAN: Lazy<tracing::Span> = Lazy::new(|| tracing::trace_span!("get_dir_path"));
+
 #[inline]
 #[tracing::instrument(level = "trace")]
 fn path_from_env(var: &str) -> Option<PathBuf> {
@@ -48,8 +51,8 @@ fn path_from_env(var: &str) -> Option<PathBuf> {
 /// - macOS/Linux/BSD: The value of `$HOME`.
 #[must_use]
 #[inline]
-#[tracing::instrument(level = "trace")]
 pub fn home_dir() -> PathBuf {
+    let _span = tracing::trace_span!(parent: &*EMPTY_SPAN, "home_dir").entered();
     sys::home_dir()
 }
 
@@ -64,8 +67,8 @@ pub fn home_dir() -> PathBuf {
 /// - Linux/BSD: `${XFG_CONFIG_HOME}/hoard`, if `XDG_CONFIG_HOME` is set, otherwise `$HOME/.config/hoard`.
 #[must_use]
 #[inline]
-#[tracing::instrument(level = "trace")]
 pub fn config_dir() -> PathBuf {
+    let _span = tracing::trace_span!(parent: &*EMPTY_SPAN, "config_dir").entered();
     path_from_env(CONFIG_DIR_ENV).unwrap_or_else(sys::config_dir)
 }
 
@@ -78,8 +81,8 @@ pub fn config_dir() -> PathBuf {
 /// - Linux/BSD: `${XFG_DATA_HOME}/hoard`, if `XDG_DATA_HOME` is set, otherwise `$HOME/.local/share/hoard`.
 #[must_use]
 #[inline]
-#[tracing::instrument(level = "trace")]
 pub fn data_dir() -> PathBuf {
+    let _span = tracing::trace_span!(parent: &*EMPTY_SPAN, "data_dir").entered();
     path_from_env(DATA_DIR_ENV).unwrap_or_else(sys::data_dir)
 }
 

--- a/src/dirs/unix.rs
+++ b/src/dirs/unix.rs
@@ -1,24 +1,29 @@
-use super::{path_from_env, PROJECT};
 use std::path::PathBuf;
 
+use super::{path_from_env, PROJECT};
 #[cfg(target_os = "macos")]
 use super::{COMPANY, TLD};
 
+#[tracing::instrument(level = "trace")]
 fn xdg_config_dir() -> Option<PathBuf> {
     path_from_env("XDG_CONFIG_HOME").map(|path| path.join(PROJECT))
 }
 
+#[tracing::instrument(level = "trace")]
 fn xdg_data_dir() -> Option<PathBuf> {
     path_from_env("XDG_DATA_HOME").map(|path| path.join(PROJECT))
 }
 
 #[must_use]
+#[tracing::instrument(level = "trace")]
 pub(super) fn home_dir() -> PathBuf {
     path_from_env("HOME").expect("could not determine user home directory")
 }
 
 #[cfg(target_os = "macos")]
+#[tracing::instrument(level = "trace")]
 fn mac_config_dir() -> PathBuf {
+    tracing::trace!("using macos-specific config/data directory");
     home_dir()
         .join("Library")
         .join("Application Support")
@@ -27,24 +32,34 @@ fn mac_config_dir() -> PathBuf {
 
 #[cfg(target_os = "macos")]
 #[must_use]
+#[tracing::instrument(level = "trace")]
 pub(super) fn config_dir() -> PathBuf {
     xdg_config_dir().unwrap_or_else(mac_config_dir)
 }
 
 #[cfg(target_os = "macos")]
 #[must_use]
+#[tracing::instrument(level = "trace")]
 pub(super) fn data_dir() -> PathBuf {
     xdg_data_dir().unwrap_or_else(mac_config_dir)
 }
 
 #[cfg(not(target_os = "macos"))]
 #[must_use]
+#[tracing::instrument(level = "trace")]
 pub(super) fn config_dir() -> PathBuf {
-    xdg_config_dir().unwrap_or_else(|| home_dir().join(".config").join(PROJECT))
+    xdg_config_dir().unwrap_or_else(|| {
+        tracing::trace!("using fallback config directory");
+        home_dir().join(".config").join(PROJECT)
+    })
 }
 
 #[cfg(not(target_os = "macos"))]
 #[must_use]
+#[tracing::instrument(level = "trace")]
 pub(super) fn data_dir() -> PathBuf {
-    xdg_data_dir().unwrap_or_else(|| home_dir().join(".local").join("share").join(PROJECT))
+    xdg_data_dir().unwrap_or_else(|| {
+        tracing::trace!("using fallback data directory");
+        home_dir().join(".local").join("share").join(PROJECT)
+    })
 }

--- a/src/dirs/win.rs
+++ b/src/dirs/win.rs
@@ -65,10 +65,10 @@ pub fn set_known_folder(folder_id: GUID, new_path: &Path) -> WinResult<()> {
 }
 
 macro_rules! get_and_log_known_folder {
-    ($id: ident) => {
+    ($id: ident) => {{
         tracing::trace!("attempting to get known folder {}", std::stringify!($id));
         get_known_folder($id)
-    };
+    }};
 }
 
 #[must_use]

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -8,7 +8,6 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{env, fmt};
-use tap::TapFallible;
 
 // Following the example of `std::env::set_var`, the only things disallowed are
 // the equals sign and the NUL character.
@@ -135,12 +134,15 @@ impl PathWithEnv {
             let var = &var[2..var.len() - 1];
             tracing::trace!(var, "found environment variable {}", var,);
 
+            // Error is not logged here because:
+            // (a) The context is not terribly important for the error
+            // (b) This is used when parsing the configuration file, so there is no
+            //     simple way to only parse the paths that apply to this system.
             let value = env::var(var)
                 .map_err(|error| Error::Env {
                     error,
                     var: var.to_string(),
-                })
-                .tap_err(crate::tap_log_error)?;
+                })?;
 
             old_start = start;
             start += mat.start() + value.len();

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -138,11 +138,10 @@ impl PathWithEnv {
             // (a) The context is not terribly important for the error
             // (b) This is used when parsing the configuration file, so there is no
             //     simple way to only parse the paths that apply to this system.
-            let value = env::var(var)
-                .map_err(|error| Error::Env {
-                    error,
-                    var: var.to_string(),
-                })?;
+            let value = env::var(var).map_err(|error| Error::Env {
+                error,
+                var: var.to_string(),
+            })?;
 
             old_start = start;
             start += mat.start() + value.len();

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -135,10 +135,12 @@ impl PathWithEnv {
             let var = &var[2..var.len() - 1];
             tracing::trace!(var, "found environment variable {}", var,);
 
-            let value = env::var(var).map_err(|error| Error::Env {
-                error,
-                var: var.to_string(),
-            }).tap_err(crate::tap_log_error)?;
+            let value = env::var(var)
+                .map_err(|error| Error::Env {
+                    error,
+                    var: var.to_string(),
+                })
+                .tap_err(crate::tap_log_error)?;
 
             old_start = start;
             start += mat.start() + value.len();

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -123,12 +123,11 @@ impl PathWithEnv {
     /// # Errors
     ///
     /// See [`Error`]
+    #[tracing::instrument(level = "debug", name = "process_path_with_env")]
     pub fn process(self) -> Result<SystemPath, Error> {
         let mut new_path = self.0;
         let mut start: usize = 0;
         let mut old_start: usize;
-
-        let _span = tracing::debug_span!("expand_env_in_path", path=%new_path).entered();
 
         while let Some(mat) = ENV_REGEX.find(&new_path[start..]) {
             let var = mat.as_str();

--- a/src/env_vars.rs
+++ b/src/env_vars.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{env, fmt};
+use tap::TapFallible;
 
 // Following the example of `std::env::set_var`, the only things disallowed are
 // the equals sign and the NUL character.
@@ -137,7 +138,7 @@ impl PathWithEnv {
             let value = env::var(var).map_err(|error| Error::Env {
                 error,
                 var: var.to_string(),
-            })?;
+            }).tap_err(crate::tap_log_error)?;
 
             old_start = start;
             start += mat.start() + value.len();

--- a/src/filters/ignore.rs
+++ b/src/filters/ignore.rs
@@ -16,24 +16,13 @@ use crate::paths::{RelativePath, SystemPath};
 
 use super::Filter;
 
-#[derive(Debug, Error)]
-pub enum Error {
-    /// An invalid glob was provided in the configuration file
-    #[error("invalid glob pattern \"{pattern}\": {error}")]
-    InvalidGlob {
-        pattern: String,
-        #[source]
-        error: PatternError,
-    },
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub(crate) struct IgnoreFilter {
     globs: Vec<Pattern>,
 }
 
 impl Filter for IgnoreFilter {
-    type Error = Error;
+    type Error = std::convert::Infallible;
 
     fn new(pile_config: &PileConfig) -> Result<Self, Self::Error> {
         Ok(IgnoreFilter {

--- a/src/filters/ignore.rs
+++ b/src/filters/ignore.rs
@@ -8,8 +8,7 @@
 /// ```
 ///
 /// This can be put under global, hoard, or pile scope.
-use glob::{Pattern, PatternError};
-use thiserror::Error;
+use glob::Pattern;
 
 use crate::hoard::PileConfig;
 use crate::paths::{RelativePath, SystemPath};
@@ -22,12 +21,10 @@ pub(crate) struct IgnoreFilter {
 }
 
 impl Filter for IgnoreFilter {
-    type Error = std::convert::Infallible;
-
-    fn new(pile_config: &PileConfig) -> Result<Self, Self::Error> {
-        Ok(IgnoreFilter {
+    fn new(pile_config: &PileConfig) -> Self {
+        IgnoreFilter {
             globs: pile_config.ignore.clone(),
-        })
+        }
     }
 
     #[tracing::instrument(name = "run_ignore_filter", skip(self, _prefix))]
@@ -56,14 +53,14 @@ mod tests {
                 ignore: vec![Pattern::new("testing/**").unwrap()],
                 ..PileConfig::default()
             };
-            IgnoreFilter::new(&config).expect("filter should be valid")
+            IgnoreFilter::new(&config)
         };
         let other = {
             let config = PileConfig {
                 ignore: vec![Pattern::new("test/**").unwrap()],
                 ..PileConfig::default()
             };
-            IgnoreFilter::new(&config).expect("filter should be valid")
+            IgnoreFilter::new(&config)
         };
         assert!(format!("{:?}", filter).contains("IgnoreFilter"));
         assert_eq!(filter, filter.clone());

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,7 +1,5 @@
 //! Provides filters for determining whether a path should be backed up or not.
 
-use thiserror::Error;
-
 use crate::hoard::PileConfig;
 use crate::paths::{RelativePath, SystemPath};
 
@@ -9,24 +7,14 @@ pub(crate) mod ignore;
 
 /// The [`Filter`] trait provides a common interface for all filters.
 pub trait Filter: Sized {
-    /// Any errors that may occur while creating a new filter.
-    type Error: std::error::Error;
     /// Creates a new instance of something that implements [`Filter`].
     ///
     /// # Errors
     ///
     /// Any errors that may occur while creating the new filter.
-    fn new(pile_config: &PileConfig) -> Result<Self, Self::Error>;
+    fn new(pile_config: &PileConfig) -> Self;
     /// Whether or not the file should be kept (backed up).
     fn keep(&self, prefix: &SystemPath, path: &RelativePath) -> bool;
-}
-
-/// Any errors that may occur while filtering.
-#[derive(Debug, Error)]
-pub enum Error {
-    /// An error occurred in the Ignore filter.
-    #[error("error occurred in the ignore filter: {0}")]
-    Ignore(#[from] ignore::Error),
 }
 
 /// A wrapper for all implmented filters.
@@ -36,12 +24,10 @@ pub struct Filters {
 }
 
 impl Filter for Filters {
-    type Error = Error;
-
     #[tracing::instrument]
-    fn new(pile_config: &PileConfig) -> Result<Self, Self::Error> {
-        let ignore = ignore::IgnoreFilter::new(pile_config)?;
-        Ok(Self { ignore })
+    fn new(pile_config: &PileConfig) -> Self {
+        let ignore = ignore::IgnoreFilter::new(pile_config);
+        Self { ignore }
     }
 
     #[tracing::instrument(name = "run_filters")]
@@ -60,7 +46,7 @@ mod tests {
             ignore: vec![glob::Pattern::new("valid/**").unwrap()],
             ..PileConfig::default()
         };
-        let filters = Filters::new(&config).expect("config should be valid");
+        let filters = Filters::new(&config);
         assert!(format!("{:?}", filters).contains("Filters"));
         assert_eq!(filters.clone().ignore, filters.ignore);
     }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -1,8 +1,9 @@
 //! Provides filters for determining whether a path should be backed up or not.
 
+use thiserror::Error;
+
 use crate::hoard::PileConfig;
 use crate::paths::{RelativePath, SystemPath};
-use thiserror::Error;
 
 pub(crate) mod ignore;
 
@@ -37,13 +38,14 @@ pub struct Filters {
 impl Filter for Filters {
     type Error = Error;
 
+    #[tracing::instrument]
     fn new(pile_config: &PileConfig) -> Result<Self, Self::Error> {
         let ignore = ignore::IgnoreFilter::new(pile_config)?;
         Ok(Self { ignore })
     }
 
+    #[tracing::instrument(name = "run_filters")]
     fn keep(&self, prefix: &SystemPath, path: &RelativePath) -> bool {
-        let _span = tracing::trace_span!("run_filters", ?prefix, ?path).entered();
         self.ignore.keep(prefix, path)
     }
 }

--- a/src/hoard/iter/all_files.rs
+++ b/src/hoard/iter/all_files.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::pin::Pin;
 
-use futures::stream::Peekable;
 use futures::{StreamExt, TryStream};
+use futures::stream::Peekable;
 use tokio::{fs, io};
 use tokio_stream::wrappers::ReadDirStream;
 
@@ -24,9 +24,9 @@ impl RootPathItem {
     fn keep(&self) -> bool {
         (!self.exists() || self.is_file() || self.is_dir())
             && self.filters.keep(
-                self.hoard_file.system_prefix(),
-                self.hoard_file.relative_path(),
-            )
+            self.hoard_file.system_prefix(),
+            self.hoard_file.relative_path(),
+        )
     }
 
     fn is_file(&self) -> bool {
@@ -72,7 +72,7 @@ impl AllFilesIter {
                         ),
                         filters,
                     }))
-                    .collect(),
+                        .collect(),
                 }
             }
             Hoard::Named(piles) => piles
@@ -81,7 +81,7 @@ impl AllFilesIter {
                 .filter_map(|(name, pile)| {
                     let filters = match Filters::new(&pile.config) {
                         Ok(filters) => filters,
-                        Err(err) => return Some(Err(super::Error::Filter(err))),
+                        Err(err) => return Some(crate::create_log_error(super::Error::Filter(err))),
                     };
                     let name_path = RelativePath::from(name);
                     pile.path.as_ref().map(|path| {
@@ -253,7 +253,7 @@ impl AllFilesIter {
                         .expect("prefix should always match path")
                         .to_path_buf(),
                 )
-                .expect("path created with strip_prefix should always be valid RelativePath");
+                    .expect("path created with strip_prefix should always be valid RelativePath");
                 Ok(Some(rel_path))
             }
             Some((Err(error), prefix)) => {
@@ -264,13 +264,11 @@ impl AllFilesIter {
                     .hoard_file
                     .relative_path()
                     .to_path_buf();
-                tracing::error!(
-                    "could not process entry in {}/{}: {}",
-                    prefix.display(),
-                    rel_path.display(),
-                    error
-                );
-                Err(error)
+                let path = prefix.join(rel_path);
+                crate::create_log_error_msg(&format!(
+                    "could not process entry in {}",
+                    path.display(),
+                ), error)
             }
         }
     }
@@ -345,12 +343,12 @@ impl AllFilesIter {
                                     if err.kind() == io::ErrorKind::NotFound {
                                         self.system_entries = None;
                                     } else {
-                                        tracing::error!(
-                                            "failed to read directory {}: {}",
-                                            system_path.display(),
-                                            err
-                                        );
-                                        return Some(Some(Err(err)));
+                                        return Some(Some(crate::create_log_error_msg(
+                                            &format!(
+                                                "failed to read directory {}",
+                                                system_path.display(),
+                                            ), err,
+                                        )));
                                     }
                                 }
                             }
@@ -362,12 +360,12 @@ impl AllFilesIter {
                                     if err.kind() == io::ErrorKind::NotFound {
                                         self.hoard_entries = None;
                                     } else {
-                                        tracing::error!(
-                                            "failed to read directory {}: {}",
-                                            hoard_path.display(),
-                                            err
-                                        );
-                                        return Some(Some(Err(err)));
+                                        return Some(Some(crate::create_log_error_msg(
+                                            &format!(
+                                                "failed to read directory {}",
+                                                hoard_path.display(),
+                                            ), err,
+                                        )));
                                     }
                                 }
                             }
@@ -416,7 +414,7 @@ pub async fn all_files_stream(
     hoards_root: &HoardPath,
     hoard_name: &HoardName,
     hoard: &Hoard,
-) -> Result<impl TryStream<Ok = HoardItem, Error = super::Error>, super::Error> {
+) -> Result<impl TryStream<Ok=HoardItem, Error=super::Error>, super::Error> {
     let mut all_files = AllFilesIter::new(hoards_root, hoard_name, hoard).await?;
     let stream = async_stream::try_stream! {
         while let Some(item) = all_files.next_item().await {

--- a/src/hoard/iter/all_files.rs
+++ b/src/hoard/iter/all_files.rs
@@ -1,16 +1,18 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::pin::Pin;
+
+use futures::stream::Peekable;
+use futures::{StreamExt, TryStream};
+use tokio::{fs, io};
+use tokio_stream::wrappers::ReadDirStream;
+
 use crate::checkers::history::operation::{ItemOperation, Operation, OperationImpl};
 use crate::filters::{Filter, Filters};
 use crate::hoard::Hoard;
 use crate::hoard_item::HoardItem;
 use crate::newtypes::{HoardName, PileName};
 use crate::paths::{HoardPath, RelativePath, SystemPath};
-use futures::stream::Peekable;
-use futures::{StreamExt, TryStream};
-use std::collections::BTreeSet;
-use std::path::PathBuf;
-use std::pin::Pin;
-use tokio::{fs, io};
-use tokio_stream::wrappers::ReadDirStream;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct RootPathItem {
@@ -40,6 +42,7 @@ impl RootPathItem {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct AllFilesIter {
     seen_paths: BTreeSet<SystemPath>,
     root_paths: Vec<RootPathItem>,
@@ -108,7 +111,6 @@ impl AllFilesIter {
     ) -> Result<Vec<RootPathItem>, super::Error> {
         // This is used to detect files deleted locally and remotely
         let from_logs: Vec<ItemOperation<HoardItem>> = {
-            let _span = tracing::trace_span!("load_paths_from_logs").entered();
             let local = Operation::latest_local(hoard_name, None)
                 .await
                 .map_err(Box::new)?;
@@ -208,6 +210,7 @@ impl AllFilesIter {
         }
     }
 
+    #[tracing::instrument]
     async fn get_next_entry_with_prefix(&mut self) -> Option<(io::Result<fs::DirEntry>, PathBuf)> {
         if let Some(stream) = self.system_entries.as_mut() {
             let prefix = self
@@ -238,6 +241,7 @@ impl AllFilesIter {
         None
     }
 
+    #[tracing::instrument]
     async fn get_next_relative_path(&mut self) -> io::Result<Option<RelativePath>> {
         match self.get_next_entry_with_prefix().await {
             None => Ok(None),
@@ -271,6 +275,7 @@ impl AllFilesIter {
         }
     }
 
+    #[tracing::instrument]
     async fn process_dir_entry(&mut self) -> Result<Option<HoardItem>, io::Error> {
         let current_root = self
             .current_root
@@ -319,6 +324,7 @@ impl AllFilesIter {
     }
 
     #[allow(clippy::option_option)]
+    #[tracing::instrument]
     async fn ensure_dir_entries(&mut self) -> Option<Option<io::Result<HoardItem>>> {
         // Attempt to create direntry iterator.
         // If a path to a file is encountered, return that.
@@ -377,6 +383,7 @@ impl AllFilesIter {
         None
     }
 
+    #[tracing::instrument]
     async fn next_item(&mut self) -> Option<io::Result<HoardItem>> {
         loop {
             if let Some(return_value) = self.ensure_dir_entries().await {
@@ -404,6 +411,7 @@ impl AllFilesIter {
 ///
 /// Any errors that may occur while building the stream. See [`Error`](super::Error) for more.
 #[allow(clippy::module_name_repetitions)]
+#[tracing::instrument]
 pub async fn all_files_stream(
     hoards_root: &HoardPath,
     hoard_name: &HoardName,

--- a/src/hoard/iter/all_files.rs
+++ b/src/hoard/iter/all_files.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::pin::Pin;
 
-use futures::{StreamExt, TryStream};
 use futures::stream::Peekable;
+use futures::{StreamExt, TryStream};
 use tokio::{fs, io};
 use tokio_stream::wrappers::ReadDirStream;
 
@@ -24,9 +24,9 @@ impl RootPathItem {
     fn keep(&self) -> bool {
         (!self.exists() || self.is_file() || self.is_dir())
             && self.filters.keep(
-            self.hoard_file.system_prefix(),
-            self.hoard_file.relative_path(),
-        )
+                self.hoard_file.system_prefix(),
+                self.hoard_file.relative_path(),
+            )
     }
 
     fn is_file(&self) -> bool {
@@ -72,7 +72,7 @@ impl AllFilesIter {
                         ),
                         filters,
                     }))
-                        .collect(),
+                    .collect(),
                 }
             }
             Hoard::Named(piles) => piles
@@ -250,7 +250,7 @@ impl AllFilesIter {
                         .expect("prefix should always match path")
                         .to_path_buf(),
                 )
-                    .expect("path created with strip_prefix should always be valid RelativePath");
+                .expect("path created with strip_prefix should always be valid RelativePath");
                 Ok(Some(rel_path))
             }
             Some((Err(error), prefix)) => {
@@ -262,10 +262,10 @@ impl AllFilesIter {
                     .relative_path()
                     .to_path_buf();
                 let path = prefix.join(rel_path);
-                crate::create_log_error_msg(&format!(
-                    "could not process entry in {}",
-                    path.display(),
-                ), error)
+                crate::create_log_error_msg(
+                    &format!("could not process entry in {}", path.display(),),
+                    error,
+                )
             }
         }
     }
@@ -344,7 +344,8 @@ impl AllFilesIter {
                                             &format!(
                                                 "failed to read directory {}",
                                                 system_path.display(),
-                                            ), err,
+                                            ),
+                                            err,
                                         )));
                                     }
                                 }
@@ -361,7 +362,8 @@ impl AllFilesIter {
                                             &format!(
                                                 "failed to read directory {}",
                                                 hoard_path.display(),
-                                            ), err,
+                                            ),
+                                            err,
                                         )));
                                     }
                                 }
@@ -411,7 +413,7 @@ pub async fn all_files_stream(
     hoards_root: &HoardPath,
     hoard_name: &HoardName,
     hoard: &Hoard,
-) -> Result<impl TryStream<Ok=HoardItem, Error=super::Error>, super::Error> {
+) -> Result<impl TryStream<Ok = HoardItem, Error = super::Error>, super::Error> {
     let mut all_files = AllFilesIter::new(hoards_root, hoard_name, hoard).await?;
     let stream = async_stream::try_stream! {
         while let Some(item) = all_files.next_item().await {

--- a/src/hoard/iter/all_files.rs
+++ b/src/hoard/iter/all_files.rs
@@ -60,7 +60,7 @@ impl AllFilesIter {
         match hoard {
             Hoard::Anonymous(pile) => {
                 let path = pile.path.clone();
-                let filters = Filters::new(&pile.config)?;
+                let filters = Filters::new(&pile.config);
                 match path {
                     None => Ok(Vec::default()),
                     Some(system_prefix) => std::iter::once(Ok(RootPathItem {
@@ -79,10 +79,7 @@ impl AllFilesIter {
                 .piles
                 .iter()
                 .filter_map(|(name, pile)| {
-                    let filters = match Filters::new(&pile.config) {
-                        Ok(filters) => filters,
-                        Err(err) => return Some(crate::create_log_error(super::Error::Filter(err))),
-                    };
+                    let filters = Filters::new(&pile.config);
                     let name_path = RelativePath::from(name);
                     pile.path.as_ref().map(|path| {
                         let hoard_prefix = hoard_name_root.join(&name_path);

--- a/src/hoard/iter/diff_files.rs
+++ b/src/hoard/iter/diff_files.rs
@@ -100,12 +100,46 @@ pub enum HoardFileDiff {
 impl fmt::Display for HoardFileDiff {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HoardFileDiff::BinaryModified { file, diff_source } => write!(f, "BinaryModified {{ source: {}, file: {} }}", diff_source, file.system_path().display()),
-            HoardFileDiff::TextModified { file, unified_diff, diff_source } => write!(f, "TextModified {{ source: {}, file: {} }}", diff_source, file.system_path().display()),
-            HoardFileDiff::Created { file, unified_diff, diff_source } => write!(f, "Created {{ source: {}, file: {} }}", diff_source, file.system_path().display()),
-            HoardFileDiff::Deleted { file, diff_source } => write!(f, "Deleted {{ source: {}, file: {} }}", diff_source, file.system_path().display()),
-            HoardFileDiff::Unchanged(file) => write!(f, "Unchanged {{ file: {} }}", file.system_path().display()),
-            HoardFileDiff::Nonexistent(file) => write!(f, "Nonexistent {{ file: {} }}", file.system_path().display()),
+            HoardFileDiff::BinaryModified { file, diff_source } => write!(
+                f,
+                "BinaryModified {{ source: {}, file: {} }}",
+                diff_source,
+                file.system_path().display()
+            ),
+            HoardFileDiff::TextModified {
+                file,
+                unified_diff,
+                diff_source,
+            } => write!(
+                f,
+                "TextModified {{ source: {}, file: {} }}",
+                diff_source,
+                file.system_path().display()
+            ),
+            HoardFileDiff::Created {
+                file,
+                unified_diff,
+                diff_source,
+            } => write!(
+                f,
+                "Created {{ source: {}, file: {} }}",
+                diff_source,
+                file.system_path().display()
+            ),
+            HoardFileDiff::Deleted { file, diff_source } => write!(
+                f,
+                "Deleted {{ source: {}, file: {} }}",
+                diff_source,
+                file.system_path().display()
+            ),
+            HoardFileDiff::Unchanged(file) => {
+                write!(f, "Unchanged {{ file: {} }}", file.system_path().display())
+            }
+            HoardFileDiff::Nonexistent(file) => write!(
+                f,
+                "Nonexistent {{ file: {} }}",
+                file.system_path().display()
+            ),
         }
     }
 }

--- a/src/hoard/iter/mod.rs
+++ b/src/hoard/iter/mod.rs
@@ -1,24 +1,21 @@
 //! This module provides async streams of hoard-managed files and associated information.
 
-use crate::checkers::history::operation::Error as OperationError;
-use crate::filters::Error as FilterError;
 use thiserror::Error;
-
-mod all_files;
-mod diff_files;
-mod operation;
 
 pub use all_files::all_files_stream;
 pub use diff_files::{changed_diff_only_stream, diff_stream, DiffSource, HoardFileDiff};
 pub use operation::operation_stream;
 
+use crate::checkers::history::operation::Error as OperationError;
+
+mod all_files;
+mod diff_files;
+mod operation;
+
 /// Errors that may occur while using a stream.
 #[derive(Debug, Error)]
 #[allow(variant_size_differences)]
 pub enum Error {
-    /// Failed to create a [`Filters`](crate::filters::Filters) instance.
-    #[error("failed to create filters: {0}")]
-    Filter(#[from] FilterError),
     /// Some I/O error occurred.
     #[error("I/O error occurred: {0}")]
     IO(#[from] tokio::io::Error),

--- a/src/hoard/iter/operation.rs
+++ b/src/hoard/iter/operation.rs
@@ -13,6 +13,7 @@ use futures::{TryStream, TryStreamExt};
 ///
 /// Any errors that may occur while initially creating the stream.
 #[allow(clippy::module_name_repetitions)]
+#[tracing::instrument]
 pub async fn operation_stream(
     hoards_root: &HoardPath,
     hoard_name: HoardName,

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -118,7 +118,7 @@ impl Hoard {
     pub fn get_paths(
         &self,
         hoards_root: HoardPath,
-    ) -> Box<dyn Iterator<Item=(PileName, HoardPath, SystemPath)>> {
+    ) -> Box<dyn Iterator<Item = (PileName, HoardPath, SystemPath)>> {
         match self {
             Hoard::Anonymous(pile) => match pile.path.clone() {
                 None => Box::new(std::iter::empty()),

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -2,19 +2,22 @@
 //! [`Hoard`](crate::config::builder::hoard::Hoard)s. See documentation for builder `Hoard`s
 //! for more details.
 
-pub mod iter;
-pub(crate) mod pile_config;
+use std::collections::HashMap;
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::io;
+
+pub use pile_config::Config as PileConfig;
 
 use crate::filters::Error as FilterError;
 use crate::newtypes::{NonEmptyPileName, PileName};
 use crate::paths::{HoardPath, RelativePath, SystemPath};
-pub use pile_config::Config as PileConfig;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fmt;
-use std::path::PathBuf;
-use thiserror::Error;
-use tokio::io;
+
+pub mod iter;
+pub(crate) mod pile_config;
 
 /// Errors that can happen while backing up or restoring a hoard.
 #[derive(Debug, Error)]
@@ -115,6 +118,7 @@ impl Hoard {
     ///
     /// The [`HoardPath`] and [`SystemPath`] represent the relevant prefix/root path for the given pile.
     #[must_use]
+    #[tracing::instrument(name = "get_hoard_paths")]
     pub fn get_paths(
         &self,
         hoards_root: HoardPath,

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -12,7 +12,6 @@ use tokio::io;
 
 pub use pile_config::Config as PileConfig;
 
-use crate::filters::Error as FilterError;
 use crate::newtypes::{NonEmptyPileName, PileName};
 use crate::paths::{HoardPath, RelativePath, SystemPath};
 
@@ -59,9 +58,6 @@ pub enum Error {
         /// Destination path.
         dest: PathBuf,
     },
-    /// An error occurred while filtering files.
-    #[error("error while filtering files: {0}")]
-    Filter(#[from] FilterError),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -122,7 +118,7 @@ impl Hoard {
     pub fn get_paths(
         &self,
         hoards_root: HoardPath,
-    ) -> Box<dyn Iterator<Item = (PileName, HoardPath, SystemPath)>> {
+    ) -> Box<dyn Iterator<Item=(PileName, HoardPath, SystemPath)>> {
         match self {
             Hoard::Anonymous(pile) => match pile.path.clone() {
                 None => Box::new(std::iter::empty()),

--- a/src/hoard/mod.rs
+++ b/src/hoard/mod.rs
@@ -114,7 +114,7 @@ pub enum Hoard {
 }
 
 impl Hoard {
-    /// Returns an iterator over all piles with associates paths.
+    /// Returns an iterator over all piles with associated paths.
     ///
     /// The [`HoardPath`] and [`SystemPath`] represent the relevant prefix/root path for the given pile.
     #[must_use]

--- a/src/hoard/pile_config.rs
+++ b/src/hoard/pile_config.rs
@@ -3,8 +3,8 @@ use std::fs::Permissions as StdPermissions;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tap::TapFallible;
 use tokio::{fs, io};
 
@@ -147,19 +147,25 @@ impl Permissions {
     pub async fn set_on_path(self, path: &Path) -> io::Result<()> {
         let perms = fs::metadata(path)
             .await
-            .tap_err(crate::tap_log_error_msg(&format!("failed to read permissions on {}", path.display())))?
+            .tap_err(crate::tap_log_error_msg(&format!(
+                "failed to read permissions on {}",
+                path.display()
+            )))?
             .permissions();
         let perms = self.set_permissions(perms);
-        fs::set_permissions(path, perms).await.tap_err(crate::tap_log_error_msg(
-            &format!("failed to set permissions on {}", path.display())
-        ))
+        fs::set_permissions(path, perms)
+            .await
+            .tap_err(crate::tap_log_error_msg(&format!(
+                "failed to set permissions on {}",
+                path.display()
+            )))
     }
 }
 
 #[allow(single_use_lifetimes)]
 fn deserialize_glob<'de, D>(deserializer: D) -> Result<Vec<glob::Pattern>, D::Error>
-    where
-        D: Deserializer<'de>,
+where
+    D: Deserializer<'de>,
 {
     Vec::<String>::deserialize(deserializer)?
         .iter()
@@ -171,8 +177,8 @@ fn deserialize_glob<'de, D>(deserializer: D) -> Result<Vec<glob::Pattern>, D::Er
 
 #[allow(clippy::ptr_arg)]
 fn serialize_glob<S>(value: &Vec<glob::Pattern>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+where
+    S: Serializer,
 {
     let value = value
         .iter()
@@ -194,9 +200,9 @@ pub struct Config {
     pub encryption: Option<Encryption>,
     /// A list of glob patterns matching files to ignore.
     #[serde(
-    default,
-    deserialize_with = "deserialize_glob",
-    serialize_with = "serialize_glob"
+        default,
+        deserialize_with = "deserialize_glob",
+        serialize_with = "serialize_glob"
     )]
     pub ignore: Vec<glob::Pattern>,
     /// The [`Permissions`] to set on restored files.

--- a/src/hoard/pile_config.rs
+++ b/src/hoard/pile_config.rs
@@ -1,11 +1,14 @@
-use crate::checksum::ChecksumType;
-use serde::de::Error as _;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fs::Permissions as StdPermissions;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::Error as _;
+use tap::TapFallible;
 use tokio::{fs, io};
+
+use crate::checksum::ChecksumType;
 
 /// Configuration for symmetric (password) encryption.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -144,27 +147,19 @@ impl Permissions {
     pub async fn set_on_path(self, path: &Path) -> io::Result<()> {
         let perms = fs::metadata(path)
             .await
-            .map_err(|err| {
-                tracing::error!(
-                    "failed to read current permissions for {}: {}",
-                    path.display(),
-                    err
-                );
-                err
-            })?
+            .tap_err(crate::tap_log_error_msg(&format!("failed to read permissions on {}", path.display())))?
             .permissions();
         let perms = self.set_permissions(perms);
-        fs::set_permissions(path, perms).await.map_err(|err| {
-            tracing::error!("failed to set permissions on {}: {}", path.display(), err);
-            err
-        })
+        fs::set_permissions(path, perms).await.tap_err(crate::tap_log_error_msg(
+            &format!("failed to set permissions on {}", path.display())
+        ))
     }
 }
 
 #[allow(single_use_lifetimes)]
 fn deserialize_glob<'de, D>(deserializer: D) -> Result<Vec<glob::Pattern>, D::Error>
-where
-    D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
 {
     Vec::<String>::deserialize(deserializer)?
         .iter()
@@ -176,8 +171,8 @@ where
 
 #[allow(clippy::ptr_arg)]
 fn serialize_glob<S>(value: &Vec<glob::Pattern>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
+    where
+        S: Serializer,
 {
     let value = value
         .iter()
@@ -199,9 +194,9 @@ pub struct Config {
     pub encryption: Option<Encryption>,
     /// A list of glob patterns matching files to ignore.
     #[serde(
-        default,
-        deserialize_with = "deserialize_glob",
-        serialize_with = "serialize_glob"
+    default,
+    deserialize_with = "deserialize_glob",
+    serialize_with = "serialize_glob"
     )]
     pub ignore: Vec<glob::Pattern>,
     /// The [`Permissions`] to set on restored files.
@@ -251,9 +246,10 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::checksum::ChecksumType;
     use crate::hoard::pile_config::Permissions;
+
+    use super::*;
 
     #[test]
     fn test_layer_configs_both_none() {

--- a/src/hoard_item/hoard_item.rs
+++ b/src/hoard_item/hoard_item.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use tap::TapFallible;
 
 use tokio::io;
 
@@ -127,7 +128,9 @@ impl HoardItem {
     }
 
     async fn content(path: &Path) -> io::Result<FileContent> {
-        FileContent::read_path(path).await
+        FileContent::read_path(path).await.tap_err(
+            crate::tap_log_error_msg(&format!("failed to read content from {}", path.display()))
+        )
     }
 
     async fn raw_content(path: &Path) -> io::Result<Option<Vec<u8>>> {

--- a/src/hoard_item/hoard_item.rs
+++ b/src/hoard_item/hoard_item.rs
@@ -128,9 +128,12 @@ impl HoardItem {
     }
 
     async fn content(path: &Path) -> io::Result<FileContent> {
-        FileContent::read_path(path).await.tap_err(
-            crate::tap_log_error_msg(&format!("failed to read content from {}", path.display()))
-        )
+        FileContent::read_path(path)
+            .await
+            .tap_err(crate::tap_log_error_msg(&format!(
+                "failed to read content from {}",
+                path.display()
+            )))
     }
 
     async fn raw_content(path: &Path) -> io::Result<Option<Vec<u8>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,9 @@ pub(crate) fn create_log_error_msg<T, E: std::error::Error>(msg: &str, error: E)
     Err(error)
 }
 
-pub(crate) fn map_log_error<E1: std::error::Error, E2: std::error::Error>(map: impl Fn(E1) -> E2) -> impl Fn(E1) -> E2 {
+pub(crate) fn map_log_error<E1: std::error::Error, E2: std::error::Error>(
+    map: impl Fn(E1) -> E2,
+) -> impl Fn(E1) -> E2 {
     move |error| {
         let error = map(error);
         tap_log_error(&error);
@@ -120,7 +122,10 @@ pub(crate) fn map_log_error<E1: std::error::Error, E2: std::error::Error>(map: i
     }
 }
 
-pub(crate) fn map_log_error_msg<'m, E1: std::error::Error, E2: std::error::Error>(msg: &'m str, map: impl Fn(E1) -> E2 + 'm) -> impl Fn(E1) -> E2 + 'm {
+pub(crate) fn map_log_error_msg<'m, E1: std::error::Error, E2: std::error::Error>(
+    msg: &'m str,
+    map: impl Fn(E1) -> E2 + 'm,
+) -> impl Fn(E1) -> E2 + 'm {
     move |error| {
         let error = map(error);
         tap_log_error_msg(msg)(&error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,44 +24,44 @@
 #![deny(clippy::pedantic)]
 #![deny(rustdoc::missing_doc_code_examples)]
 #![deny(
-    absolute_paths_not_starting_with_crate,
-    anonymous_parameters,
-    bad_style,
-    const_err,
-    dead_code,
-    keyword_idents,
-    improper_ctypes,
-    macro_use_extern_crate,
-    meta_variable_misuse, // May have false positives
-    missing_abi,
-    missing_debug_implementations, // can affect compile time/code size
-    missing_docs,
-    no_mangle_generic_items,
-    non_shorthand_field_patterns,
-    noop_method_call,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    pointer_structural_match,
-    private_in_public,
-    semicolon_in_expressions_from_macros,
-    single_use_lifetimes,
-    trivial_casts,
-    trivial_numeric_casts,
-    unaligned_references,
-    unconditional_recursion,
-    unreachable_pub,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_lifetimes,
-    unused_parens,
-    unused_qualifications,
-    variant_size_differences,
-    while_true
+absolute_paths_not_starting_with_crate,
+anonymous_parameters,
+bad_style,
+const_err,
+dead_code,
+keyword_idents,
+improper_ctypes,
+macro_use_extern_crate,
+meta_variable_misuse, // May have false positives
+missing_abi,
+missing_debug_implementations, // can affect compile time/code size
+missing_docs,
+no_mangle_generic_items,
+non_shorthand_field_patterns,
+noop_method_call,
+overflowing_literals,
+path_statements,
+patterns_in_fns_without_body,
+pointer_structural_match,
+private_in_public,
+semicolon_in_expressions_from_macros,
+single_use_lifetimes,
+trivial_casts,
+trivial_numeric_casts,
+unaligned_references,
+unconditional_recursion,
+unreachable_pub,
+unsafe_code,
+unused,
+unused_allocation,
+unused_comparisons,
+unused_extern_crates,
+unused_import_braces,
+unused_lifetimes,
+unused_parens,
+unused_qualifications,
+variant_size_differences,
+while_true
 )]
 
 pub use config::Config;
@@ -87,3 +87,41 @@ pub const CONFIG_FILE_STEM: &str = "config";
 
 /// The name of the directory containing the backed up hoards.
 pub const HOARDS_DIR_SLUG: &str = "hoards";
+
+#[inline]
+pub(crate) fn tap_log_error<E: std::error::Error>(error: &E) {
+    tracing::error!(%error);
+}
+
+#[inline]
+pub(crate) fn tap_log_error_msg<E: std::error::Error>(msg: &str, error: &E) {
+    tracing::error!(%error, "{}", msg);
+}
+
+#[inline]
+pub(crate) fn create_log_error<T, E: std::error::Error>(error: E) -> Result<T, E> {
+    tap_log_error(&error);
+    Err(error)
+}
+
+#[inline]
+pub(crate) fn create_log_error_msg<T, E: std::error::Error>(msg: &str, error: E) -> Result<T, E> {
+    tap_log_error_msg(msg, &error);
+    Err(error)
+}
+
+pub(crate) fn map_log_error<E1: std::error::Error, E2: std::error::Error>(map: impl Fn(E1) -> E2) -> impl Fn(E1) -> E2 {
+    move |error| {
+        let error = map(error);
+        tap_log_error(&error);
+        error
+    }
+}
+
+pub(crate) fn map_log_error_msg<'m, E1: std::error::Error, E2: std::error::Error>(msg: &'m str, map: impl Fn(E1) -> E2 + 'm) -> impl Fn(E1) -> E2 + 'm {
+    move |error| {
+        let error = map(error);
+        tap_log_error_msg(msg, &error);
+        error
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub(crate) fn tap_log_error<E: std::error::Error>(error: &E) {
 }
 
 #[inline]
-pub(crate) fn tap_log_error_msg<'m, E: std::error::Error>(msg: &'m str) -> impl Fn(&E) + 'm {
+pub(crate) fn tap_log_error_msg<E: std::error::Error>(msg: &'_ str) -> impl Fn(&E) + '_ {
     move |error| {
         tracing::error!(%error, "{}", msg);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,10 @@ pub(crate) fn tap_log_error<E: std::error::Error>(error: &E) {
 }
 
 #[inline]
-pub(crate) fn tap_log_error_msg<E: std::error::Error>(msg: &str, error: &E) {
-    tracing::error!(%error, "{}", msg);
+pub(crate) fn tap_log_error_msg<'m, E: std::error::Error>(msg: &'m str) -> impl Fn(&E) + 'm {
+    move |error| {
+        tracing::error!(%error, "{}", msg);
+    }
 }
 
 #[inline]
@@ -106,7 +108,7 @@ pub(crate) fn create_log_error<T, E: std::error::Error>(error: E) -> Result<T, E
 
 #[inline]
 pub(crate) fn create_log_error_msg<T, E: std::error::Error>(msg: &str, error: E) -> Result<T, E> {
-    tap_log_error_msg(msg, &error);
+    tap_log_error_msg(msg)(&error);
     Err(error)
 }
 
@@ -121,7 +123,7 @@ pub(crate) fn map_log_error<E1: std::error::Error, E2: std::error::Error>(map: i
 pub(crate) fn map_log_error_msg<'m, E1: std::error::Error, E2: std::error::Error>(msg: &'m str, map: impl Fn(E1) -> E2 + 'm) -> impl Fn(E1) -> E2 + 'm {
     move |error| {
         let error = map(error);
-        tap_log_error_msg(msg, &error);
+        tap_log_error_msg(msg)(&error);
         error
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -141,7 +141,7 @@ where
         writeln!(writer)?;
 
         // Format spans only if tracing verbosity
-        if self.max_level == Level::TRACE {
+        if matches!(self.max_level, Level::TRACE | Level::DEBUG) {
             if let Some(scope) = ctx.event_scope() {
                 for span in scope.from_root() {
                     write!(writer, "{}at {}", EMPTY_PREFIX, span.name())?;

--- a/src/newtypes/environment_name.rs
+++ b/src/newtypes/environment_name.rs
@@ -14,6 +14,7 @@ pub struct EnvironmentName(String);
 
 impl FromStr for EnvironmentName {
     type Err = Error;
+    #[tracing::instrument(level = "trace", name = "parse_environment_name")]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         validate_name(s.to_string()).map(Self)
     }
@@ -45,8 +46,9 @@ impl<'de> Deserialize<'de> for EnvironmentName {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_test::{assert_tokens, Token};
+
+    use super::*;
 
     #[test]
     fn test_from_str() {

--- a/src/newtypes/environment_name.rs
+++ b/src/newtypes/environment_name.rs
@@ -53,10 +53,10 @@ mod tests {
     #[test]
     fn test_from_str() {
         let inputs = [
-            ("", Err(Error::InvalidName(String::from("")))),
+            ("", Err(Error::DisallowedName(String::from("")))),
             (
                 "invalid name",
-                Err(Error::InvalidName(String::from("invalid name"))),
+                Err(Error::DisallowedCharacters(String::from("invalid name"))),
             ),
             ("valid", Ok(EnvironmentName(String::from("valid")))),
         ];

--- a/src/newtypes/environment_string.rs
+++ b/src/newtypes/environment_string.rs
@@ -214,7 +214,7 @@ mod tests {
                         s1, s2,
                         "expected invalid name to be \"{}\", got \"{}\"",
                         s1, s2
-                    )
+                    );
                 }
             }
         }

--- a/src/newtypes/environment_string.rs
+++ b/src/newtypes/environment_string.rs
@@ -14,6 +14,7 @@ pub struct EnvironmentString(BTreeSet<EnvironmentName>);
 impl FromStr for EnvironmentString {
     type Err = Error;
 
+    #[tracing::instrument(level = "trace", name = "parse_environment_string")]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.split('|')
             .map(EnvironmentName::from_str)

--- a/src/newtypes/environment_string.rs
+++ b/src/newtypes/environment_string.rs
@@ -61,8 +61,8 @@ impl fmt::Display for EnvironmentString {
 
 impl<'de> Deserialize<'de> for EnvironmentString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let inner = String::deserialize(deserializer)?;
         inner.parse().map_err(D::Error::custom)
@@ -71,8 +71,8 @@ impl<'de> Deserialize<'de> for EnvironmentString {
 
 impl Serialize for EnvironmentString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&self.to_string())
     }
@@ -209,11 +209,13 @@ mod tests {
                 (Some(s), Error::EmptyName) => {
                     panic!("expected Error::InvalidName(\"{}\"), got {:?}", s, error)
                 }
-                (Some(s1), Error::DisallowedName(s2) | Error::DisallowedCharacters(s2)) => assert_eq!(
-                    s1, s2,
-                    "expected invalid name to be \"{}\", got \"{}\"",
-                    s1, s2
-                ),
+                (Some(s1), Error::DisallowedName(s2) | Error::DisallowedCharacters(s2)) => {
+                    assert_eq!(
+                        s1, s2,
+                        "expected invalid name to be \"{}\", got \"{}\"",
+                        s1, s2
+                    )
+                }
             }
         }
     }

--- a/src/newtypes/environment_string.rs
+++ b/src/newtypes/environment_string.rs
@@ -1,8 +1,10 @@
-use super::{EnvironmentName, Error};
-use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
+
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{EnvironmentName, Error};
 
 /// Newtype wrapper for `HashSet<EnvironmentName>` representing a list of environments.
 ///
@@ -59,8 +61,8 @@ impl fmt::Display for EnvironmentString {
 
 impl<'de> Deserialize<'de> for EnvironmentString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         let inner = String::deserialize(deserializer)?;
         inner.parse().map_err(D::Error::custom)
@@ -69,8 +71,8 @@ impl<'de> Deserialize<'de> for EnvironmentString {
 
 impl Serialize for EnvironmentString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         serializer.serialize_str(&self.to_string())
     }
@@ -100,8 +102,9 @@ impl EnvironmentString {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_test::{assert_tokens, Token};
+
+    use super::*;
 
     const NAME_1: &str = "3rd";
     const NAME_2: &str = "FIRST";
@@ -200,13 +203,13 @@ mod tests {
             let error = EnvironmentString::from_str(s).expect_err("input string should be invalid");
             match (expected, &error) {
                 (None, Error::EmptyName) => {}
-                (None, Error::InvalidName(_)) => {
+                (None, _) => {
                     panic!("expected Error::EmptyName, got {:?}", error)
                 }
                 (Some(s), Error::EmptyName) => {
                     panic!("expected Error::InvalidName(\"{}\"), got {:?}", s, error)
                 }
-                (Some(s1), Error::InvalidName(s2)) => assert_eq!(
+                (Some(s1), Error::DisallowedName(s2) | Error::DisallowedCharacters(s2)) => assert_eq!(
                     s1, s2,
                     "expected invalid name to be \"{}\", got \"{}\"",
                     s1, s2

--- a/src/newtypes/hoard_name.rs
+++ b/src/newtypes/hoard_name.rs
@@ -59,14 +59,14 @@ mod tests {
     #[test]
     fn test_from_str() {
         let inputs = [
-            (String::from(""), Err(Error::InvalidName(String::from("")))),
+            (String::from(""), Err(Error::DisallowedName(String::from("")))),
             (
                 String::from("config"),
-                Err(Error::InvalidName(String::from("config"))),
+                Err(Error::DisallowedName(String::from("config"))),
             ),
             (
                 String::from("bad name"),
-                Err(Error::InvalidName(String::from("bad name"))),
+                Err(Error::DisallowedCharacters(String::from("bad name"))),
             ),
             (String::from("valid"), Ok(HoardName(String::from("valid")))),
         ];

--- a/src/newtypes/hoard_name.rs
+++ b/src/newtypes/hoard_name.rs
@@ -59,7 +59,10 @@ mod tests {
     #[test]
     fn test_from_str() {
         let inputs = [
-            (String::from(""), Err(Error::DisallowedName(String::from("")))),
+            (
+                String::from(""),
+                Err(Error::DisallowedName(String::from(""))),
+            ),
             (
                 String::from("config"),
                 Err(Error::DisallowedName(String::from("config"))),

--- a/src/newtypes/hoard_name.rs
+++ b/src/newtypes/hoard_name.rs
@@ -14,6 +14,7 @@ pub struct HoardName(String);
 
 impl FromStr for HoardName {
     type Err = Error;
+    #[tracing::instrument(level = "trace", name = "parse_hoard_name")]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         validate_name(s.to_string()).map(Self)
     }

--- a/src/newtypes/mod.rs
+++ b/src/newtypes/mod.rs
@@ -44,7 +44,8 @@ fn validate_name(name: String) -> Result<String, Error> {
 
     if DISALLOWED_NAMES
         .iter()
-        .any(|disallowed| &name == disallowed) {
+        .any(|disallowed| &name == disallowed)
+    {
         return crate::create_log_error(Error::DisallowedName(name));
     }
 

--- a/src/newtypes/mod.rs
+++ b/src/newtypes/mod.rs
@@ -5,17 +5,17 @@
 
 use thiserror::Error;
 
-mod environment_name;
-mod environment_string;
-mod hoard_name;
-mod non_empty_pile_name;
-mod pile_name;
-
 pub use environment_name::EnvironmentName;
 pub use environment_string::EnvironmentString;
 pub use hoard_name::HoardName;
 pub use non_empty_pile_name::NonEmptyPileName;
 pub use pile_name::PileName;
+
+mod environment_name;
+mod environment_string;
+mod hoard_name;
+mod non_empty_pile_name;
+mod pile_name;
 
 /// Errors that may occur while creating an instance of one of this newtypes.
 #[derive(Debug, Error, PartialEq)]
@@ -30,6 +30,7 @@ pub enum Error {
 
 const DISALLOWED_NAMES: [&str; 2] = ["", "config"];
 
+#[tracing::instrument(level = "trace")]
 fn validate_name(name: String) -> Result<String, Error> {
     if name
         .chars()

--- a/src/newtypes/non_empty_pile_name.rs
+++ b/src/newtypes/non_empty_pile_name.rs
@@ -82,14 +82,14 @@ mod tests {
     #[test]
     fn test_from_str_and_try_from_string() {
         let inputs = vec![
-            (String::from(""), Err(Error::InvalidName(String::from("")))),
+            (String::from(""), Err(Error::DisallowedName(String::from("")))),
             (
                 String::from("testing"),
                 Ok(NonEmptyPileName(String::from("testing"))),
             ),
             (
                 String::from("config"),
-                Err(Error::InvalidName(String::from("config"))),
+                Err(Error::DisallowedName(String::from("config"))),
             ),
         ];
 

--- a/src/newtypes/non_empty_pile_name.rs
+++ b/src/newtypes/non_empty_pile_name.rs
@@ -82,7 +82,10 @@ mod tests {
     #[test]
     fn test_from_str_and_try_from_string() {
         let inputs = vec![
-            (String::from(""), Err(Error::DisallowedName(String::from("")))),
+            (
+                String::from(""),
+                Err(Error::DisallowedName(String::from(""))),
+            ),
             (
                 String::from("testing"),
                 Ok(NonEmptyPileName(String::from("testing"))),

--- a/src/newtypes/non_empty_pile_name.rs
+++ b/src/newtypes/non_empty_pile_name.rs
@@ -34,6 +34,7 @@ impl fmt::Display for NonEmptyPileName {
 impl FromStr for NonEmptyPileName {
     type Err = Error;
 
+    #[tracing::instrument(level = "trace", name = "parse_non_empty_pile_name")]
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         validate_name(value.to_string()).map(Self)
     }
@@ -42,6 +43,7 @@ impl FromStr for NonEmptyPileName {
 impl TryFrom<String> for NonEmptyPileName {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "non_empty_pile_name_try_from_string")]
     fn try_from(value: String) -> Result<Self, Self::Error> {
         validate_name(value).map(Self)
     }

--- a/src/newtypes/pile_name.rs
+++ b/src/newtypes/pile_name.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use std::{fmt, ops::Deref};
+use std::str::FromStr;
 
 use serde::{de, Deserialize, Deserializer, Serialize};
 
@@ -35,22 +35,22 @@ impl<'de> de::Visitor<'de> for PileNameVisitor {
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
+        where
+            E: de::Error,
     {
         v.parse().map_err(E::custom)
     }
 
     fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         deserializer.deserialize_str(self)
     }
 
     fn visit_none<E>(self) -> Result<Self::Value, E>
-    where
-        E: de::Error,
+        where
+            E: de::Error,
     {
         Ok(PileName(None))
     }
@@ -58,16 +58,16 @@ impl<'de> de::Visitor<'de> for PileNameVisitor {
 
 impl<'de> Deserialize<'de> for PileName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         deserializer.deserialize_any(PileNameVisitor)
     }
 }
 
 impl<T> TryFrom<Option<T>> for PileName
-where
-    T: AsRef<str>,
+    where
+        T: AsRef<str>,
 {
     type Error = Error;
 
@@ -153,11 +153,11 @@ mod tests {
     #[test]
     fn test_from_str() {
         let inputs = vec![
-            ("", Err(Error::InvalidName(String::from("")))),
+            ("", Err(Error::DisallowedName(String::from("")))),
             ("name", Ok(PileName(Some("name".parse().unwrap())))),
             (
                 "invalid name",
-                Err(Error::InvalidName(String::from("invalid name"))),
+                Err(Error::DisallowedCharacters(String::from("invalid name"))),
             ),
         ];
 
@@ -172,7 +172,7 @@ mod tests {
                     (Error::EmptyName, _) | (_, Error::EmptyName) => {
                         panic!("expected {:?}, got {:?}", err1, err2);
                     }
-                    (Error::InvalidName(invalid1), Error::InvalidName(invalid2)) => {
+                    (Error::DisallowedName(invalid1) | Error::DisallowedCharacters(invalid1), Error::DisallowedName(invalid2) | Error::DisallowedCharacters(invalid2)) => {
                         assert_eq!(
                             invalid1, invalid2,
                             "expected invalid string to be {}, was {}",

--- a/src/newtypes/pile_name.rs
+++ b/src/newtypes/pile_name.rs
@@ -206,7 +206,7 @@ mod tests {
     fn test_serde_empty_str() {
         serde_test::assert_de_tokens_error::<PileName>(
             &[Token::Str("")],
-            "invalid name: \"\": must contain only alphanumeric characters",
+            "name \"\" is not allowed",
         );
     }
 

--- a/src/newtypes/pile_name.rs
+++ b/src/newtypes/pile_name.rs
@@ -1,7 +1,9 @@
-use super::{Error, NonEmptyPileName};
-use serde::{de, Deserialize, Deserializer, Serialize};
 use std::str::FromStr;
 use std::{fmt, ops::Deref};
+
+use serde::{de, Deserialize, Deserializer, Serialize};
+
+use super::{Error, NonEmptyPileName};
 
 /// Newtype wrapper for `Option<String>` representing a pile name.
 ///
@@ -17,6 +19,7 @@ pub struct PileName(Option<NonEmptyPileName>);
 impl FromStr for PileName {
     type Err = Error;
 
+    #[tracing::instrument(level = "trace", name = "parse_pile_name")]
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         NonEmptyPileName::from_str(value).map(Some).map(Self)
     }
@@ -68,6 +71,7 @@ where
 {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "pile_name_try_from_option_str", skip_all)]
     fn try_from(value: Option<T>) -> Result<Self, Self::Error> {
         match value {
             None => Ok(Self(None)),
@@ -85,6 +89,7 @@ impl From<NonEmptyPileName> for PileName {
 impl TryFrom<PileName> for NonEmptyPileName {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "non_empty_pile_name_try_from_pile_name")]
     fn try_from(value: PileName) -> Result<Self, Self::Error> {
         Option::<Self>::from(value).ok_or(Error::EmptyName)
     }
@@ -141,8 +146,9 @@ impl PileName {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_test::{assert_de_tokens, assert_tokens, Token};
+
+    use super::*;
 
     #[test]
     fn test_from_str() {

--- a/src/newtypes/pile_name.rs
+++ b/src/newtypes/pile_name.rs
@@ -1,5 +1,5 @@
-use std::{fmt, ops::Deref};
 use std::str::FromStr;
+use std::{fmt, ops::Deref};
 
 use serde::{de, Deserialize, Deserializer, Serialize};
 
@@ -35,22 +35,22 @@ impl<'de> de::Visitor<'de> for PileNameVisitor {
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
+    where
+        E: de::Error,
     {
         v.parse().map_err(E::custom)
     }
 
     fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_str(self)
     }
 
     fn visit_none<E>(self) -> Result<Self::Value, E>
-        where
-            E: de::Error,
+    where
+        E: de::Error,
     {
         Ok(PileName(None))
     }
@@ -58,16 +58,16 @@ impl<'de> de::Visitor<'de> for PileNameVisitor {
 
 impl<'de> Deserialize<'de> for PileName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_any(PileNameVisitor)
     }
 }
 
 impl<T> TryFrom<Option<T>> for PileName
-    where
-        T: AsRef<str>,
+where
+    T: AsRef<str>,
 {
     type Error = Error;
 
@@ -172,7 +172,10 @@ mod tests {
                     (Error::EmptyName, _) | (_, Error::EmptyName) => {
                         panic!("expected {:?}, got {:?}", err1, err2);
                     }
-                    (Error::DisallowedName(invalid1) | Error::DisallowedCharacters(invalid1), Error::DisallowedName(invalid2) | Error::DisallowedCharacters(invalid2)) => {
+                    (
+                        Error::DisallowedName(invalid1) | Error::DisallowedCharacters(invalid1),
+                        Error::DisallowedName(invalid2) | Error::DisallowedCharacters(invalid2),
+                    ) => {
                         assert_eq!(
                             invalid1, invalid2,
                             "expected invalid string to be {}, was {}",

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -10,8 +10,8 @@ use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 use crate::newtypes::{HoardName, NonEmptyPileName, PileName};
@@ -69,8 +69,8 @@ pub fn normalize_path(path: &Path) -> PathBuf {
 fn is_valid_absolute(path: &Path) -> bool {
     path.is_absolute()
         && path
-        .components()
-        .all(|comp| !matches!(comp, Component::ParentDir))
+            .components()
+            .all(|comp| !matches!(comp, Component::ParentDir))
 }
 
 /// Errors that may be returned when using [`TryFrom`] on a path wrapper.
@@ -174,7 +174,7 @@ impl HoardPath {
                 .as_ref()
                 .map_or_else(|| self.0.clone(), |rel_path| self.0.join(&rel_path)),
         )
-            .expect("a HoardPath rooted in an existing HoardPath is always valid")
+        .expect("a HoardPath rooted in an existing HoardPath is always valid")
     }
 }
 
@@ -233,7 +233,7 @@ impl SystemPath {
                 .as_ref()
                 .map_or_else(|| self.0.clone(), |rel_path| self.0.join(&rel_path)),
         )
-            .expect("a SystemPath rooted in an existing SystemPath is always valid")
+        .expect("a SystemPath rooted in an existing SystemPath is always valid")
     }
 }
 
@@ -252,8 +252,8 @@ pub struct RelativePath(Option<PathBuf>);
 
 impl Serialize for RelativePath {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         self.0
             .clone()
@@ -264,8 +264,8 @@ impl Serialize for RelativePath {
 
 impl<'de> Deserialize<'de> for RelativePath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let path = PathBuf::deserialize(deserializer)?;
         Self::try_from(path).map_err(D::Error::custom)
@@ -427,9 +427,9 @@ mod tests {
         #[test]
         fn test_absolute_paths_not_allowed() {
             #[cfg(unix)]
-                let bin_path = PathBuf::from("/bin/sh");
+            let bin_path = PathBuf::from("/bin/sh");
             #[cfg(windows)]
-                let bin_path = PathBuf::from("C:\\Windows\\System32\\cmd.exe");
+            let bin_path = PathBuf::from("C:\\Windows\\System32\\cmd.exe");
 
             let home_path = crate::dirs::home_dir().join("file.txt");
 
@@ -512,9 +512,9 @@ mod tests {
                 RelativePath(Some(valid_path))
             );
             #[cfg(unix)]
-                let invalid_path = PathBuf::from("/invalid/path");
+            let invalid_path = PathBuf::from("/invalid/path");
             #[cfg(windows)]
-                let invalid_path = PathBuf::from("C:\\\\invalid\\path");
+            let invalid_path = PathBuf::from("C:\\\\invalid\\path");
 
             assert!(
                 invalid_path.is_absolute(),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -4,18 +4,21 @@
 //! - [`SystemPath`]
 //! - [`RelativePath`]
 
-use crate::newtypes::{HoardName, NonEmptyPileName, PileName};
-use serde::de::Error as _;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
+
+use crate::newtypes::{HoardName, NonEmptyPileName, PileName};
 
 /// Returns the default root for hoard files.
 #[must_use]
+#[tracing::instrument(level = "trace")]
 pub fn hoards_dir() -> HoardPath {
     HoardPath::try_from(crate::dirs::data_dir().join("hoards"))
         .expect("HoardPath that is the hoards directory should always be valid")
@@ -133,6 +136,7 @@ impl Deref for HoardPath {
 impl TryFrom<PathBuf> for HoardPath {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "hoard_path_try_from_path")]
     fn try_from(input: PathBuf) -> Result<Self, Self::Error> {
         let value = normalize_path(&input);
         if !is_valid_absolute(&value) {
@@ -199,6 +203,7 @@ impl Deref for SystemPath {
 impl TryFrom<PathBuf> for SystemPath {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "system_path_try_from_path")]
     fn try_from(input: PathBuf) -> Result<Self, Self::Error> {
         let value = normalize_path(&input);
         if !is_valid_absolute(&value) {
@@ -270,6 +275,7 @@ impl<'de> Deserialize<'de> for RelativePath {
 impl TryFrom<PathBuf> for RelativePath {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "relative_path_try_from_path")]
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
         let normalized = normalize_path(&value);
 
@@ -288,6 +294,7 @@ impl TryFrom<PathBuf> for RelativePath {
 impl TryFrom<Option<PathBuf>> for RelativePath {
     type Error = Error;
 
+    #[tracing::instrument(level = "trace", name = "relative_path_try_from_path_option")]
     fn try_from(value: Option<PathBuf>) -> Result<Self, Self::Error> {
         match value {
             None => Ok(Self(None)),


### PR DESCRIPTION
Resolves #95.

The primary purpose of this branch is to make sure errors are reported at the creation site (or where they enter this crate's code).

There are a couple logic fixes that got applied too, though, as part of this,